### PR TITLE
feat(swift): add CI to swift repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+
+version: 2.1
+
+orbs:
+  macos: circleci/macos@2
+
+jobs:
+  tests:
+    macos:
+      xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
+
+    steps:
+      - macos/preboot-simulator:
+          version: "17.5"
+          platform: "iOS"
+          device: "iPhone 15"
+      - checkout
+      - run: xcodebuild -version
+      - run: xcodebuild test -scheme honeycomb-opentelemetry-swift -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
+
+workflows:
+  unit-tests:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - tests
+

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,9 @@ let package = Package(
     name: "honeycomb-opentelemetry-swift",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v12),
-        .tvOS(.v12)
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
## Which problem is this PR solving?

Adds iOS unit tests to CircleCI.

## Short description of the changes

* This follows [the online documentation](https://circleci.com/docs/using-macos/) for running CI on macOS.
* I didn't use `fastlane`, because it seems like overkill for now.
* For now, this only includes tests for iOS. If we want to include tests for macOS, tvOS, etc in the future, we can.
* I also updated `Package.swift` to better match OpenTelemetry. I hadn't noticed, but OpenTelemetry has multiple different `Package.swift` files for different swift-tools versions. We are only targeting the most recent ones for now, so I updated our package to match it. This was required to make the tests pass locally.

## How to verify that this has the expected result

Unfortunately, macos CI [cannot be tested locally](https://discuss.circleci.com/t/remote-docker-is-not-available-on-this-installation-error-when-running-local-macos-job/36507). So we'll have to push the change and see what happens. I did verify the following:

```
$ circleci config validate .circleci/config.yml
Config file at .circleci/config.yml is valid.
```

```
$ xcodebuild test -scheme honeycomb-opentelemetry-swift -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'

...

** TEST SUCCEEDED **
```