### PR TITLE
feat(swift): add MetricKit support

### DIFF
--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -1,6 +1,7 @@
 
 import Foundation
 import GRPC
+import MetricKit
 import NIO
 import OpenTelemetryApi
 import OpenTelemetrySdk
@@ -35,7 +36,9 @@ private func createKeyValueList(_ dict: [String: String]) -> [(String, String)] 
     return result
 }
 
-class Honeycomb {
+public class Honeycomb {
+  static private let metricKitSubscriber = MetricKitSubscriber()
+  
     static public func configure(options: HoneycombOptions) throws {
         guard let tracesEndpoint = URL(string:options.tracesEndpoint) else {
             throw HoneycombOptionsError.malformedURL(options.tracesEndpoint)
@@ -143,5 +146,7 @@ class Honeycomb {
         OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
         OpenTelemetry.registerMeterProvider(meterProvider: meterProvider)
         OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
+
+      MXMetricManager.shared.add(self.metricKitSubscriber)
     }
 }

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -147,6 +147,6 @@ public class Honeycomb {
         OpenTelemetry.registerMeterProvider(meterProvider: meterProvider)
         OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
 
-      MXMetricManager.shared.add(self.metricKitSubscriber)
+       MXMetricManager.shared.add(self.metricKitSubscriber)
     }
 }

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -167,7 +167,7 @@ extension Dictionary {
  * https://opentelemetry.io/docs/languages/sdk-configuration/general/
  * https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/
  */
-class HoneycombOptions {
+public class HoneycombOptions {
     let tracesApiKey: String
     let metricsApiKey: String
     let logsApiKey: String
@@ -248,7 +248,7 @@ class HoneycombOptions {
         self.logsProtocol = logsProtocol
     }
     
-    class Builder {
+    public class Builder {
         private var apiKey: String? = nil
         private var tracesApiKey: String? = nil
         private var metricsApiKey: String? = nil
@@ -287,7 +287,7 @@ class HoneycombOptions {
         private var logsProtocol: OTLPProtocol? = nil
         
         /** Creates a builder with default options. */
-        init() {}
+        public init() {}
         
         internal convenience init(source: HoneycombOptionsSource) throws {
             self.init()
@@ -295,7 +295,7 @@ class HoneycombOptions {
         }
 
         /** Creates a build with options pre-propulated from a plist file. */
-        convenience init(contentsOfFile path: URL) throws {
+        public convenience init(contentsOfFile path: URL) throws {
             let data = try Data(contentsOf: path)
             let info = try PropertyListSerialization.propertyList(from: data, options: .mutableContainers, format: nil) as? [String: Any]
             try self.init(source: HoneycombOptionsSource(info: info))
@@ -338,152 +338,152 @@ class HoneycombOptions {
             logsProtocol = try source.getOTLPProtocol(otlpLogsProtocolKey)
         }
 
-        func setAPIKey(_ apiKey: String) -> Builder {
+        public func setAPIKey(_ apiKey: String) -> Builder {
             self.apiKey = apiKey
             return self
         }
 
-        func setTracesApiKey(_ apiKey: String) -> Builder {
+        public func setTracesApiKey(_ apiKey: String) -> Builder {
             tracesApiKey = apiKey
             return self
         }
 
-        func setMetricsApiKey(_ apiKey: String) -> Builder {
+        public func setMetricsApiKey(_ apiKey: String) -> Builder {
             metricsApiKey = apiKey
             return self
         }
 
-        func setLogsApiKey(_ apiKey: String) -> Builder {
+        public func setLogsApiKey(_ apiKey: String) -> Builder {
             logsApiKey = apiKey
             return self
         }
 
-        func setDataset(_ dataset: String) -> Builder {
+        public func setDataset(_ dataset: String) -> Builder {
             self.dataset = dataset
             return self
         }
 
-        func setMetricsDataset(_ dataset: String) -> Builder {
+        public func setMetricsDataset(_ dataset: String) -> Builder {
             metricsDataset = dataset
             return self
         }
 
-        func setApiEndpoint(_ endpoint: String) -> Builder {
+        public func setApiEndpoint(_ endpoint: String) -> Builder {
             apiEndpoint = endpoint
             return self
         }
 
-        func setTracesApiEndpoint(_ endpoint: String) -> Builder {
+        public func setTracesApiEndpoint(_ endpoint: String) -> Builder {
             tracesEndpoint = endpoint
             return self
         }
 
-        func setMetricsApiEndpoint(_ endpoint: String) -> Builder {
+        public func setMetricsApiEndpoint(_ endpoint: String) -> Builder {
             metricsEndpoint = endpoint
             return self
         }
 
-        func setLogsApiEndpoint(_ endpoint: String) -> Builder {
+        public func setLogsApiEndpoint(_ endpoint: String) -> Builder {
             logsEndpoint = endpoint
             return self
         }
 
-        func setSampleRate(_ sampleRate: Int) -> Builder {
+        public func setSampleRate(_ sampleRate: Int) -> Builder {
             self.sampleRate = sampleRate
             return self
         }
 
-        func setDebug(_ debug: Bool) -> Builder {
+        public func setDebug(_ debug: Bool) -> Builder {
             self.debug = debug
             return self
         }
 
-        func setServiceName(_ serviceName: String) -> Builder {
+        public func setServiceName(_ serviceName: String) -> Builder {
             self.serviceName = serviceName
             return self
         }
 
-        func setResourceAttributes(_ resources: [String: String]) -> Builder {
+        public func setResourceAttributes(_ resources: [String: String]) -> Builder {
             resourceAttributes = resources
             return self
         }
 
-        func setTracesSampler(_ sampler: String) -> Builder {
+        public func setTracesSampler(_ sampler: String) -> Builder {
             tracesSampler = sampler
             return self
         }
 
-        func setTracesSamplerArg(_ arg: String?) -> Builder {
+        public func setTracesSamplerArg(_ arg: String?) -> Builder {
             tracesSamplerArg = arg
             return self
         }
 
-        func setPropagators(_ propagators: String) -> Builder {
+        public func setPropagators(_ propagators: String) -> Builder {
             self.propagators = propagators
             return self
         }
 
-        func setHeaders(_ headers: [String: String]) -> Builder {
+        public func setHeaders(_ headers: [String: String]) -> Builder {
             self.headers = headers
             return self
         }
 
-        func setTracesHeaders(_ headers: [String: String]) -> Builder {
+        public func setTracesHeaders(_ headers: [String: String]) -> Builder {
             tracesHeaders = headers
             return self
         }
 
-        func setMetricsHeaders(_ headers: [String: String]) -> Builder {
+        public func setMetricsHeaders(_ headers: [String: String]) -> Builder {
             metricsHeaders = headers
             return self
         }
 
-        func setLogsHeaders(_ headers: [String: String]) -> Builder {
+        public func setLogsHeaders(_ headers: [String: String]) -> Builder {
             logsHeaders = headers
             return self
         }
 
-        func setTimeout(_ timeout: TimeInterval) -> Builder {
+        public func setTimeout(_ timeout: TimeInterval) -> Builder {
             self.timeout = timeout
             return self
         }
 
-        func setTracesTimeout(_ timeout: TimeInterval) -> Builder {
+        public func setTracesTimeout(_ timeout: TimeInterval) -> Builder {
             tracesTimeout = timeout
             return self
         }
 
-        func setMetricsTimeout(_ timeout: TimeInterval) -> Builder {
+        public func setMetricsTimeout(_ timeout: TimeInterval) -> Builder {
             metricsTimeout = timeout
             return self
         }
 
-        func setLogsTimeout(_ timeout: TimeInterval) -> Builder {
+        public func setLogsTimeout(_ timeout: TimeInterval) -> Builder {
             logsTimeout = timeout
             return self
         }
 
-        func setProtocol(_ protocol: OTLPProtocol) -> Builder {
+        public func setProtocol(_ protocol: OTLPProtocol) -> Builder {
             self.`protocol` = `protocol`
             return self
         }
 
-        func setTracesProtocol(_ protocol: OTLPProtocol) -> Builder {
+        public func setTracesProtocol(_ protocol: OTLPProtocol) -> Builder {
             tracesProtocol = `protocol`
             return self
         }
 
-        func setMetricsProtocol(_ protocol: OTLPProtocol) -> Builder {
+        public func setMetricsProtocol(_ protocol: OTLPProtocol) -> Builder {
             metricsProtocol = `protocol`
             return self
         }
 
-        func setLogsProtocol(_ protocol: OTLPProtocol) -> Builder {
+        public func setLogsProtocol(_ protocol: OTLPProtocol) -> Builder {
             logsProtocol = `protocol`
             return self
         }
 
-        func build() throws -> HoneycombOptions {
+        public func build() throws -> HoneycombOptions {
             // If any API key isn't set, consider it a fatal error.
             let defaultApiKey: () throws -> String = {
                 if (self.apiKey == nil) {

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -81,7 +81,7 @@ func estimateHistogramAverage<UnitType>(_ histogram: MXHistogram<UnitType>) -> M
     let bucket = bucket as! MXHistogramBucket<UnitType>
     let estimatedValue = (bucket.bucketStart + bucket.bucketEnd) / 2.0
     let count = Double(bucket.bucketCount)
-    let estimatedSum =
+    estimatedSum =
       if let previousSum = estimatedSum {
         previousSum + estimatedValue * count
       } else {
@@ -163,7 +163,24 @@ func reportMetrics(payload: MXMetricPayload) {
     }
   }
   withCategory(payload.applicationResponsivenessMetrics, "app_responsiveness") {
-    captureMetric(key: "app_hang_time_average", value: $0.histogrammedApplicationHangTime)
+    captureMetric(key: "hang_time_average", value: $0.histogrammedApplicationHangTime)
+  }
+  withCategory(payload.cellularConditionMetrics, "cellular_condition") {
+    captureMetric(key: "bars_average", value: $0.histogrammedCellularConditionTime)
+  }
+  withCategory(payload.locationActivityMetrics, "location_activity") {
+    captureMetric(key: "best_accuracy_time", value: $0.cumulativeBestAccuracyTime)
+    captureMetric(key: "best_accuracy_for_nav_time", value: $0.cumulativeBestAccuracyForNavigationTime)
+    captureMetric(key: "accuracy_10m_time", value: $0.cumulativeNearestTenMetersAccuracyTime)
+    captureMetric(key: "accuracy_100m_time", value: $0.cumulativeHundredMetersAccuracyTime)
+    captureMetric(key: "accuracy_1km_time", value: $0.cumulativeKilometerAccuracyTime)
+    captureMetric(key: "accuracy_3km_time", value: $0.cumulativeThreeKilometersAccuracyTime)
+  }
+  withCategory(payload.networkTransferMetrics, "network_transfer") {
+    captureMetric(key: "cellular_download", value: $0.cumulativeCellularDownload)
+    captureMetric(key: "cellular_upload", value: $0.cumulativeCellularUpload)
+    captureMetric(key: "wifi_download", value: $0.cumulativeWifiDownload)
+    captureMetric(key: "wifi_upload", value: $0.cumulativeWifiUpload)
   }
   if #available(iOS 14.0, *) {
     withCategory(payload.applicationExitMetrics, "app_exit") {
@@ -346,27 +363,27 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
     logForEach(payload.appLaunchDiagnostics, "app_launch") {
       [
         "name": "app_launch",
-        "launch_duration": $0.launchDuration.value,
+        "launch_duration": $0.launchDuration,
       ]
     }
   }
   logForEach(payload.diskWriteExceptionDiagnostics, "disk_write_exception") {
     [
       "name": "disk_write_exception",
-      "total_writes_caused": $0.totalWritesCaused.value,
+      "total_writes_caused": $0.totalWritesCaused,
     ]
   }
   logForEach(payload.hangDiagnostics, "hang") {
     [
       "name": "hang",
-      "hang_duration": $0.hangDuration.value,
+      "hang_duration": $0.hangDuration,
     ]
   }
   logForEach(payload.cpuExceptionDiagnostics, "cpu_exception") {
     [
       "name": "cpu_exception",
       "total_cpu_time": $0.totalCPUTime,
-      "total_sampled_time": $0.totalSampledTime.value,
+      "total_sampled_time": $0.totalSampledTime,
     ]
   }
   logForEach(payload.crashDiagnostics, "crash") {

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -1,0 +1,312 @@
+import Foundation
+import MetricKit
+import OpenTelemetryApi
+
+class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
+  func didReceive(_ payloads: [MXMetricPayload]) {
+    for payload in payloads {
+      reportMetrics(payload: payload)
+    }
+  }
+
+  @available(iOS 14.0, *)
+  func didReceive(_ payloads: [MXDiagnosticPayload]) {
+    for payload in payloads {
+      reportDiagnostics(payload: payload)
+    }
+  }
+}
+
+// MARK: - AttributeValue helpers
+
+/// A protocol to make it easier to write generic functions for AttributeValues.
+protocol AttributeValueConvertable {
+  func attributeValue() -> AttributeValue
+}
+
+extension Int: AttributeValueConvertable {
+  func attributeValue() -> AttributeValue {
+    AttributeValue.int(self)
+  }
+}
+extension Bool: AttributeValueConvertable {
+  func attributeValue() -> AttributeValue {
+    AttributeValue.bool(self)
+  }
+}
+extension String: AttributeValueConvertable {
+  func attributeValue() -> AttributeValue {
+    AttributeValue.string(self)
+  }
+}
+extension TimeInterval: AttributeValueConvertable {
+  func attributeValue() -> AttributeValue {
+    AttributeValue.double(self)
+  }
+}
+extension Measurement: AttributeValueConvertable {
+  func attributeValue() -> AttributeValue {
+    AttributeValue.double(self.value)
+  }
+}
+
+// MARK: - MetricKit helpers
+
+// TODO: Figure out how to set OTel Metrics as well.
+
+func reportMetrics(payload: MXMetricPayload) {
+  // TODO: Use the correct version.
+  let version = "0.0.1"
+
+  let tracer = OpenTelemetry.instance.tracerProvider.get(
+    instrumentationName: "@honeycombio/instrumentation-metric-kit-metrics",
+    instrumentationVersion: version)
+
+  let span = tracer.spanBuilder(spanName: "metric-kit-metrics")
+    .setStartTime(time: payload.timeStampBegin)
+    .startSpan()
+  defer { span.end(time: payload.timeStampEnd) }
+
+  // There are so many nested metrics we want to capture, it's worth setting up some helper
+  // methods to reduce the amount of repeated code.
+
+  func captureMetric(key: String, value: AttributeValueConvertable) {
+    span.setAttribute(key: key, value: value.attributeValue())
+  }
+
+  // Helper functions for sending histograms, specifically.
+  func captureMetric<T>(key: String, value histogram: MXHistogram<T>) {
+    // Estimate the average value of the whole histogram, and attach that to the span.
+    var estimatedSum = 0.0
+    var sampleCount = 0.0
+    for bucket in histogram.bucketEnumerator {
+      let bucket = bucket as! MXHistogramBucket<T>
+      let estimatedValue = (bucket.bucketStart + bucket.bucketEnd) / 2.0
+      let count = Double(bucket.bucketCount)
+      estimatedSum += estimatedValue.value * count
+      sampleCount += count
+    }
+    let estimatedAverage = estimatedSum / sampleCount
+    captureMetric(key: key, value: estimatedAverage)
+  }
+
+  // This helper makes it easier to process each category without typing its name repeatedly.
+  func withCategory<T>(_ parent: T?, using closure: (T) -> Void) {
+    if let p = parent {
+      closure(p)
+    }
+  }
+
+  captureMetric(
+    key: "includes-multiple-application-versions",
+    value: payload.includesMultipleApplicationVersions)
+  captureMetric(key: "latest-application-version", value: payload.latestApplicationVersion)
+  captureMetric(key: "timestamp-begin", value: payload.timeStampBegin.timeIntervalSince1970)
+  captureMetric(key: "timestamp-end", value: payload.timeStampEnd.timeIntervalSince1970)
+
+  withCategory(payload.applicationLaunchMetrics) {
+    captureMetric(key: "time-to-first-draw-histogram", value: $0.histogrammedTimeToFirstDraw)
+    if #available(iOS 15.2, *) {
+      captureMetric(
+        key: "optimized-time-to-first-draw-histogram",
+        value: $0.histogrammedOptimizedTimeToFirstDraw)
+    }
+    if #available(iOS 16.0, *) {
+      captureMetric(key: "extended-launch-histogram", value: $0.histogrammedExtendedLaunch)
+    }
+    captureMetric(
+      key: "application-resume-time-histogram", value: $0.histogrammedApplicationResumeTime)
+  }
+  withCategory(payload.applicationResponsivenessMetrics) {
+    captureMetric(key: "application-hang-time-histogram", value: $0.histogrammedApplicationHangTime)
+  }
+  if #available(iOS 14.0, *) {
+    withCategory(payload.applicationExitMetrics) {
+      captureMetric(
+        key: "foreground-cumulative-abnormal-exit-count",
+        value: $0.foregroundExitData.cumulativeAbnormalExitCount)
+      captureMetric(
+        key: "foreground-cumulative-app-watchdog-exit-count",
+        value: $0.foregroundExitData.cumulativeAppWatchdogExitCount)
+      captureMetric(
+        key: "foreground-cumulative-bad-access-exit-count",
+        value: $0.foregroundExitData.cumulativeBadAccessExitCount)
+      captureMetric(
+        key: "foreground-cumulative-illegal-instruction-exit-count",
+        value: $0.foregroundExitData.cumulativeIllegalInstructionExitCount)
+      captureMetric(
+        key: "foreground-cumulative-memory-resource-limit-exit-count",
+        value: $0.foregroundExitData.cumulativeMemoryResourceLimitExitCount)
+      captureMetric(
+        key: "foreground-cumulative-normal-app-exit-count",
+        value: $0.foregroundExitData.cumulativeNormalAppExitCount)
+
+      captureMetric(
+        key: "background-cumulative-abnormal-exit-count",
+        value: $0.backgroundExitData.cumulativeAbnormalExitCount)
+      captureMetric(
+        key: "background-cumulative-app-watchdog-exit-count",
+        value: $0.backgroundExitData.cumulativeAppWatchdogExitCount)
+      captureMetric(
+        key: "background-cumulative-bad-access-exit-count",
+        value: $0.backgroundExitData.cumulativeBadAccessExitCount)
+      captureMetric(
+        key: "background-cumulative-normal-app-exit-count",
+        value: $0.backgroundExitData.cumulativeNormalAppExitCount)
+      captureMetric(
+        key: "background-cumulative-memory-pressure-exit-count",
+        value: $0.backgroundExitData.cumulativeMemoryPressureExitCount)
+      captureMetric(
+        key: "background-cumulative-illegal-instruction-exit-count",
+        value: $0.backgroundExitData.cumulativeIllegalInstructionExitCount)
+      captureMetric(
+        key: "background-cumulative-cpu-resource-limit-exit-count",
+        value: $0.backgroundExitData.cumulativeCPUResourceLimitExitCount)
+      captureMetric(
+        key: "background-cumulative-memory-resource-limit-exit-count",
+        value: $0.backgroundExitData.cumulativeMemoryResourceLimitExitCount)
+      captureMetric(
+        key: "background-cumulative-suspended-with-locked-file-exit-count",
+        value: $0.backgroundExitData.cumulativeSuspendedWithLockedFileExitCount)
+      captureMetric(
+        key: "background-cumulative-background-task-assertion-timeout-exit-count",
+        value: $0.backgroundExitData.cumulativeBackgroundTaskAssertionTimeoutExitCount)
+    }
+  }
+  if #available(iOS 14.0, *) {
+    withCategory(payload.animationMetrics) {
+      captureMetric(key: "scroll-hitch-time-ratio", value: $0.scrollHitchTimeRatio)
+    }
+  }
+  withCategory(payload.applicationTimeMetrics) {
+    captureMetric(
+      key: "cumulative-foreground-time",
+      value: $0.cumulativeForegroundTime)
+    captureMetric(
+      key: "cumulative-background-time",
+      value: $0.cumulativeBackgroundTime)
+    captureMetric(
+      key: "cumulative-background-audio-time",
+      value: $0.cumulativeBackgroundAudioTime)
+    captureMetric(
+      key: "cumulative-background-location-time",
+      value: $0.cumulativeBackgroundLocationTime)
+  }
+  withCategory(payload.cellularConditionMetrics) {
+    captureMetric(
+      key: "cellular-condition-time-histogram",
+      value: $0.histogrammedCellularConditionTime)
+  }
+  withCategory(payload.cpuMetrics) {
+    if #available(iOS 14.0, *) {
+      captureMetric(key: "cumulative-cpu-instructions", value: $0.cumulativeCPUInstructions)
+    }
+    captureMetric(key: "cumulative-cpu-time", value: $0.cumulativeCPUTime)
+  }
+  withCategory(payload.gpuMetrics) {
+    captureMetric(key: "cumulative-gpu-time", value: $0.cumulativeGPUTime)
+  }
+  withCategory(payload.diskIOMetrics) {
+    captureMetric(key: "cumulative-logical-writes", value: $0.cumulativeLogicalWrites)
+  }
+  // Display metrics *only* has pixel luminance, and it's an MXAverage value.
+  withCategory(payload.displayMetrics?.averagePixelLuminance) {
+    captureMetric(key: "average-pixel-luminance", value: $0.averageMeasurement)
+    captureMetric(key: "average-pixel-luminance-stddev", value: $0.standardDeviation)
+    captureMetric(key: "average-pixel-luminance-sample-count", value: $0.sampleCount)
+  }
+
+  // Signpost metrics are a little different from the other metrics, since they can have arbitrary names.
+  if let signpostMetrics = payload.signpostMetrics {
+    for signpostMetric in signpostMetrics {
+      let span = tracer.spanBuilder(spanName: "signpost-metric").startSpan()
+      span.setAttribute(key: "name", value: signpostMetric.signpostName)
+      span.setAttribute(key: "category", value: signpostMetric.signpostCategory)
+      span.setAttribute(key: "count", value: signpostMetric.totalCount)
+      span.end()
+    }
+  }
+}
+
+@available(iOS 14.0, *)
+func reportDiagnostics(payload: MXDiagnosticPayload) {
+  // TODO: Use the correct version.
+  let version = "0.0.1"
+
+  let tracer = OpenTelemetry.instance.tracerProvider.get(
+    instrumentationName: "@honeycombio/instrumentation-metric-kit-diagnostics",
+    instrumentationVersion: version)
+
+  let span = tracer.spanBuilder(spanName: "metric-kit-diagnostics")
+    .setStartTime(time: payload.timeStampBegin)
+    .startSpan()
+  defer { span.end() }
+
+  let logger = OpenTelemetry.instance.loggerProvider.get(
+    instrumentationScopeName: "@honeycombio/instrumentation-metric-kit-diagnostics")
+
+  let now = Date()
+
+  // A helper for looping over the items in an optional list and logging each one.
+  func logForEach<T>(_ parent: [T]?, using closure: (T) -> [String: AttributeValueConvertable]) {
+    if let arr = parent {
+      for item in arr {
+        let attributes = closure(item).mapValues { $0.attributeValue() }
+
+        logger.logRecordBuilder()
+          .setTimestamp(payload.timeStampEnd)
+          .setObservedTimestamp(now)
+          .setAttributes(attributes)
+          .emit()
+      }
+    }
+  }
+
+  if #available(iOS 16.0, *) {
+    logForEach(payload.appLaunchDiagnostics) {
+      ["name": "app-launch", "launch-duration": $0.launchDuration.value]
+    }
+  }
+  logForEach(payload.diskWriteExceptionDiagnostics) {
+    ["name": "disk-write-exception", "total-writes-caused": $0.totalWritesCaused.value]
+  }
+  logForEach(payload.hangDiagnostics) {
+    ["name": "hang", "hang-duration": $0.hangDuration.value]
+  }
+  logForEach(payload.cpuExceptionDiagnostics) {
+    [
+      "name": "cpu-exception",
+      "total-cpu-time": $0.totalCPUTime,
+      "total-sampled-time": $0.totalSampledTime.value,
+    ]
+  }
+  logForEach(payload.crashDiagnostics) {
+    var attrs: [String: AttributeValueConvertable] = ["name": "crash"]
+    if let exceptionCode = $0.exceptionCode {
+      attrs["exception-code"] = exceptionCode.intValue
+    }
+    if let exceptionType = $0.exceptionType {
+      // Include the original field, but also the semantic convention otel equivalent.
+      attrs["exception-type"] = exceptionType.intValue
+      attrs["exception.type"] = "\(exceptionType.intValue)"
+    }
+    if let signal = $0.signal {
+      attrs["signal"] = signal.intValue
+    }
+    if let terminationReason = $0.terminationReason {
+      attrs["termination-reason"] = terminationReason
+    }
+    if #available(iOS 17.0, *) {
+      if let exceptionReason = $0.exceptionReason {
+        attrs["exception.type"] = exceptionReason.exceptionType
+        attrs["exception.message"] = exceptionReason.composedMessage
+
+        attrs["exception-reason-class-name"] = exceptionReason.className
+        attrs["exception-reason-composed-message"] = exceptionReason.composedMessage
+        attrs["exception-reason-exception-name"] = exceptionReason.exceptionName
+        attrs["exception-reason-exception-type"] = exceptionReason.exceptionType
+      }
+    }
+    return attrs
+  }
+}

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -336,7 +336,7 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
   defer { span.end() }
 
   let logger = OpenTelemetry.instance.loggerProvider.get(
-    instrumentationScopeName: "@honeycombio/instrumentation-metric-kit-diagnostics")
+    instrumentationScopeName: metricKitInstrumentationName)
 
   let now = Date()
 

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -43,12 +43,21 @@ extension String: AttributeValueConvertable {
 }
 extension TimeInterval: AttributeValueConvertable {
   func attributeValue() -> AttributeValue {
+    // The OTel standard for time durations is seconds, which is also what TimeInterval is.
+    // https://opentelemetry.io/docs/specs/semconv/general/metrics/
     AttributeValue.double(self)
   }
 }
 extension Measurement: AttributeValueConvertable {
   func attributeValue() -> AttributeValue {
-    AttributeValue.double(self.value)
+    // Convert to the "base unit", such as seconds or bytes.
+    let value =
+      if let unit = self.unit as? Dimension {
+        unit.converter.baseUnitValue(fromValue: self.value)
+      } else {
+        self.value
+      }
+    return AttributeValue.double(value)
   }
 }
 
@@ -62,6 +71,27 @@ func getMetricKitTracer() -> Tracer {
     instrumentationVersion: honeycombLibraryVersion)
 }
 
+/// Estimates the average value of the whole histogram.
+func estimateHistogramAverage<UnitType>(_ histogram: MXHistogram<UnitType>) -> Measurement<
+  UnitType
+>? {
+  var estimatedSum: Measurement<UnitType>?
+  var sampleCount = 0.0
+  for bucket in histogram.bucketEnumerator {
+    let bucket = bucket as! MXHistogramBucket<UnitType>
+    let estimatedValue = (bucket.bucketStart + bucket.bucketEnd) / 2.0
+    let count = Double(bucket.bucketCount)
+    let estimatedSum =
+      if let previousSum = estimatedSum {
+        previousSum + estimatedValue * count
+      } else {
+        estimatedValue * count
+      }
+    sampleCount += count
+  }
+  return estimatedSum.map { $0 / sampleCount }
+}
+
 func reportMetrics(payload: MXMetricPayload) {
   let span = getMetricKitTracer().spanBuilder(spanName: "MXMetricPayload")
     .setStartTime(time: payload.timeStampBegin)
@@ -71,159 +101,210 @@ func reportMetrics(payload: MXMetricPayload) {
   // There are so many nested metrics we want to capture, it's worth setting up some helper
   // methods to reduce the amount of repeated code.
 
+  var namespaceStack = ["metrickit"]
+
   func captureMetric(key: String, value: AttributeValueConvertable) {
-    span.setAttribute(key: key, value: value.attributeValue())
+    let namespace = namespaceStack.joined(separator: ".")
+    span.setAttribute(key: "\(namespace).\(key)", value: value.attributeValue())
   }
 
   // Helper functions for sending histograms, specifically.
-  func captureMetric<T>(key: String, value histogram: MXHistogram<T>) {
-    // Estimate the average value of the whole histogram, and attach that to the span.
-    var estimatedSum = 0.0
-    var sampleCount = 0.0
-    for bucket in histogram.bucketEnumerator {
-      let bucket = bucket as! MXHistogramBucket<T>
-      let estimatedValue = (bucket.bucketStart + bucket.bucketEnd) / 2.0
-      let count = Double(bucket.bucketCount)
-      estimatedSum += estimatedValue.value * count
-      sampleCount += count
+  func captureMetric<UnitType>(key: String, value histogram: MXHistogram<UnitType>) {
+    if let average = estimateHistogramAverage(histogram) {
+      captureMetric(key: key, value: average)
     }
-    let estimatedAverage = estimatedSum / sampleCount
-    captureMetric(key: key, value: estimatedAverage)
   }
 
   // This helper makes it easier to process each category without typing its name repeatedly.
-  func withCategory<T>(_ parent: T?, using closure: (T) -> Void) {
+  func withCategory<T>(_ parent: T?, _ namespace: String, using closure: (T) -> Void) {
+    namespaceStack.append(namespace)
     if let p = parent {
       closure(p)
     }
+    namespaceStack.removeLast()
   }
 
-  captureMetric(
-    key: "includes-multiple-application-versions",
-    value: payload.includesMultipleApplicationVersions)
-  captureMetric(key: "latest-application-version", value: payload.latestApplicationVersion)
-  captureMetric(key: "timestamp-begin", value: payload.timeStampBegin.timeIntervalSince1970)
-  captureMetric(key: "timestamp-end", value: payload.timeStampEnd.timeIntervalSince1970)
+  // These attribute names follow the guidelines at
+  // https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/
 
-  withCategory(payload.applicationLaunchMetrics) {
-    captureMetric(key: "time-to-first-draw-histogram", value: $0.histogrammedTimeToFirstDraw)
+  captureMetric(
+    key: "includes_multiple_application_versions",
+    value: payload.includesMultipleApplicationVersions)
+  captureMetric(key: "latest_application-version", value: payload.latestApplicationVersion)
+  captureMetric(key: "timestamp_begin", value: payload.timeStampBegin.timeIntervalSince1970)
+  captureMetric(key: "timestamp_end", value: payload.timeStampEnd.timeIntervalSince1970)
+
+  withCategory(payload.metaData, "metadata") {
+    captureMetric(key: "app_build_version", value: $0.applicationBuildVersion)
+    captureMetric(key: "device_type", value: $0.deviceType)
+    captureMetric(key: "os_version", value: $0.osVersion)
+    captureMetric(key: "region_format", value: $0.regionFormat)
+    if #available(iOS 14.0, *) {
+      captureMetric(key: "platform_arch", value: $0.platformArchitecture)
+    }
+    if #available(iOS 17.0, *) {
+      captureMetric(key: "is_test_flight_app", value: $0.isTestFlightApp)
+      captureMetric(key: "low_power_mode_enabled", value: $0.lowPowerModeEnabled)
+      captureMetric(key: "pid", value: Int($0.pid))
+    }
+  }
+  withCategory(payload.applicationLaunchMetrics, "app_launch") {
+    captureMetric(key: "time_to_first_draw_average", value: $0.histogrammedTimeToFirstDraw)
+    captureMetric(
+      key: "app_resume_time_average",
+      value: $0.histogrammedApplicationResumeTime)
     if #available(iOS 15.2, *) {
       captureMetric(
-        key: "optimized-time-to-first-draw-histogram",
+        key: "optimized_time_to_first_draw_average",
         value: $0.histogrammedOptimizedTimeToFirstDraw)
     }
     if #available(iOS 16.0, *) {
-      captureMetric(key: "extended-launch-histogram", value: $0.histogrammedExtendedLaunch)
+      captureMetric(key: "extended_launch_average", value: $0.histogrammedExtendedLaunch)
     }
-    captureMetric(
-      key: "application-resume-time-histogram", value: $0.histogrammedApplicationResumeTime)
   }
-  withCategory(payload.applicationResponsivenessMetrics) {
-    captureMetric(key: "application-hang-time-histogram", value: $0.histogrammedApplicationHangTime)
+  withCategory(payload.applicationResponsivenessMetrics, "app_responsiveness") {
+    captureMetric(key: "app_hang_time_average", value: $0.histogrammedApplicationHangTime)
   }
   if #available(iOS 14.0, *) {
-    withCategory(payload.applicationExitMetrics) {
-      captureMetric(
-        key: "foreground-cumulative-abnormal-exit-count",
-        value: $0.foregroundExitData.cumulativeAbnormalExitCount)
-      captureMetric(
-        key: "foreground-cumulative-app-watchdog-exit-count",
-        value: $0.foregroundExitData.cumulativeAppWatchdogExitCount)
-      captureMetric(
-        key: "foreground-cumulative-bad-access-exit-count",
-        value: $0.foregroundExitData.cumulativeBadAccessExitCount)
-      captureMetric(
-        key: "foreground-cumulative-illegal-instruction-exit-count",
-        value: $0.foregroundExitData.cumulativeIllegalInstructionExitCount)
-      captureMetric(
-        key: "foreground-cumulative-memory-resource-limit-exit-count",
-        value: $0.foregroundExitData.cumulativeMemoryResourceLimitExitCount)
-      captureMetric(
-        key: "foreground-cumulative-normal-app-exit-count",
-        value: $0.foregroundExitData.cumulativeNormalAppExitCount)
+    withCategory(payload.applicationExitMetrics, "app_exit") {
+      withCategory($0.foregroundExitData, "foreground") {
+        captureMetric(
+          key: "abnormal_exit_count",
+          value: $0.cumulativeAbnormalExitCount)
+        captureMetric(
+          key: "app_watchdog_exit_count",
+          value: $0.cumulativeAppWatchdogExitCount)
+        captureMetric(
+          key: "bad_access_exit_count",
+          value: $0.cumulativeBadAccessExitCount)
+        captureMetric(
+          key: "illegal_instruction_exit_count",
+          value: $0.cumulativeIllegalInstructionExitCount)
+        captureMetric(
+          key: "memory_resource_limit_exit-count",
+          value: $0.cumulativeMemoryResourceLimitExitCount)
+        captureMetric(
+          key: "normal_app_exit_count",
+          value: $0.cumulativeNormalAppExitCount)
+      }
 
-      captureMetric(
-        key: "background-cumulative-abnormal-exit-count",
-        value: $0.backgroundExitData.cumulativeAbnormalExitCount)
-      captureMetric(
-        key: "background-cumulative-app-watchdog-exit-count",
-        value: $0.backgroundExitData.cumulativeAppWatchdogExitCount)
-      captureMetric(
-        key: "background-cumulative-bad-access-exit-count",
-        value: $0.backgroundExitData.cumulativeBadAccessExitCount)
-      captureMetric(
-        key: "background-cumulative-normal-app-exit-count",
-        value: $0.backgroundExitData.cumulativeNormalAppExitCount)
-      captureMetric(
-        key: "background-cumulative-memory-pressure-exit-count",
-        value: $0.backgroundExitData.cumulativeMemoryPressureExitCount)
-      captureMetric(
-        key: "background-cumulative-illegal-instruction-exit-count",
-        value: $0.backgroundExitData.cumulativeIllegalInstructionExitCount)
-      captureMetric(
-        key: "background-cumulative-cpu-resource-limit-exit-count",
-        value: $0.backgroundExitData.cumulativeCPUResourceLimitExitCount)
-      captureMetric(
-        key: "background-cumulative-memory-resource-limit-exit-count",
-        value: $0.backgroundExitData.cumulativeMemoryResourceLimitExitCount)
-      captureMetric(
-        key: "background-cumulative-suspended-with-locked-file-exit-count",
-        value: $0.backgroundExitData.cumulativeSuspendedWithLockedFileExitCount)
-      captureMetric(
-        key: "background-cumulative-background-task-assertion-timeout-exit-count",
-        value: $0.backgroundExitData.cumulativeBackgroundTaskAssertionTimeoutExitCount)
+      withCategory($0.backgroundExitData, "background") {
+        captureMetric(
+          key: "abnormal_exit_count",
+          value: $0.cumulativeAbnormalExitCount)
+        captureMetric(
+          key: "app_watchdog_exit_count",
+          value: $0.cumulativeAppWatchdogExitCount)
+        captureMetric(
+          key: "bad_access-exit_count",
+          value: $0.cumulativeBadAccessExitCount)
+        captureMetric(
+          key: "normal_app_exit_count",
+          value: $0.cumulativeNormalAppExitCount)
+        captureMetric(
+          key: "memory_pressure_exit_count",
+          value: $0.cumulativeMemoryPressureExitCount)
+        captureMetric(
+          key: "illegal_instruction_exit_count",
+          value: $0.cumulativeIllegalInstructionExitCount)
+        captureMetric(
+          key: "cpu_resource_limit_exit_count",
+          value: $0.cumulativeCPUResourceLimitExitCount)
+        captureMetric(
+          key: "memory_resource_limit_exit_count",
+          value: $0.cumulativeMemoryResourceLimitExitCount)
+        captureMetric(
+          key: "suspended_with_locked_file_exit_count",
+          value: $0.cumulativeSuspendedWithLockedFileExitCount)
+        captureMetric(
+          key: "background_task_assertion_timeout_exit_count",
+          value: $0.cumulativeBackgroundTaskAssertionTimeoutExitCount)
+      }
     }
   }
   if #available(iOS 14.0, *) {
-    withCategory(payload.animationMetrics) {
-      captureMetric(key: "scroll-hitch-time-ratio", value: $0.scrollHitchTimeRatio)
+    withCategory(payload.animationMetrics, "animation") {
+      captureMetric(key: "scroll_hitch_time_ratio", value: $0.scrollHitchTimeRatio)
     }
   }
-  withCategory(payload.applicationTimeMetrics) {
+  withCategory(payload.applicationTimeMetrics, "app_time") {
     captureMetric(
-      key: "cumulative-foreground-time",
+      key: "foreground_time",
       value: $0.cumulativeForegroundTime)
     captureMetric(
-      key: "cumulative-background-time",
+      key: "background_time",
       value: $0.cumulativeBackgroundTime)
     captureMetric(
-      key: "cumulative-background-audio-time",
+      key: "background_audio_time",
       value: $0.cumulativeBackgroundAudioTime)
     captureMetric(
-      key: "cumulative-background-location-time",
+      key: "background_location_time",
       value: $0.cumulativeBackgroundLocationTime)
   }
-  withCategory(payload.cellularConditionMetrics) {
+  withCategory(payload.cellularConditionMetrics, "cellular_condition") {
     captureMetric(
-      key: "cellular-condition-time-histogram",
+      key: "cellular_condition_time_average",
       value: $0.histogrammedCellularConditionTime)
   }
-  withCategory(payload.cpuMetrics) {
+  withCategory(payload.cpuMetrics, "cpu") {
     if #available(iOS 14.0, *) {
-      captureMetric(key: "cumulative-cpu-instructions", value: $0.cumulativeCPUInstructions)
+      captureMetric(key: "instruction_count", value: $0.cumulativeCPUInstructions)
     }
-    captureMetric(key: "cumulative-cpu-time", value: $0.cumulativeCPUTime)
+    captureMetric(key: "cpu_time", value: $0.cumulativeCPUTime)
   }
-  withCategory(payload.gpuMetrics) {
-    captureMetric(key: "cumulative-gpu-time", value: $0.cumulativeGPUTime)
+  withCategory(payload.gpuMetrics, "gpu") {
+    captureMetric(key: "time", value: $0.cumulativeGPUTime)
   }
-  withCategory(payload.diskIOMetrics) {
-    captureMetric(key: "cumulative-logical-writes", value: $0.cumulativeLogicalWrites)
+  withCategory(payload.diskIOMetrics, "diskio") {
+    captureMetric(key: "logical_write_count", value: $0.cumulativeLogicalWrites)
+  }
+  withCategory(payload.memoryMetrics, "memory") {
+    captureMetric(key: "peak_memory_usage", value: $0.peakMemoryUsage)
+    captureMetric(
+      key: "suspended_memory_average", value: $0.averageSuspendedMemory.averageMeasurement)
   }
   // Display metrics *only* has pixel luminance, and it's an MXAverage value.
-  withCategory(payload.displayMetrics?.averagePixelLuminance) {
-    captureMetric(key: "average-pixel-luminance", value: $0.averageMeasurement)
-    captureMetric(key: "average-pixel-luminance-stddev", value: $0.standardDeviation)
-    captureMetric(key: "average-pixel-luminance-sample-count", value: $0.sampleCount)
+  withCategory(payload.displayMetrics, "display") {
+    if let averagePixelLuminance = $0.averagePixelLuminance {
+      captureMetric(key: "pixel_luminance_average", value: averagePixelLuminance.averageMeasurement)
+    }
   }
 
   // Signpost metrics are a little different from the other metrics, since they can have arbitrary names.
   if let signpostMetrics = payload.signpostMetrics {
     for signpostMetric in signpostMetrics {
       let span = getMetricKitTracer().spanBuilder(spanName: "MXSignpostMetric").startSpan()
-      span.setAttribute(key: "name", value: signpostMetric.signpostName)
-      span.setAttribute(key: "category", value: signpostMetric.signpostCategory)
-      span.setAttribute(key: "count", value: signpostMetric.totalCount)
+      span.setAttribute(key: "signpost.name", value: signpostMetric.signpostName)
+      span.setAttribute(key: "signpost.category", value: signpostMetric.signpostCategory)
+      span.setAttribute(key: "signpost.count", value: signpostMetric.totalCount)
+      if let intervalData = signpostMetric.signpostIntervalData {
+        //override var histogrammedSignpostDuration: MXHistogram<UnitDuration> {
+        if let cpuTime = intervalData.cumulativeCPUTime {
+          span.setAttribute(
+            key: "signpost.cpu_time",
+            value: cpuTime.attributeValue()
+          )
+        }
+        if let memoryAverage = intervalData.averageMemory {
+          span.setAttribute(
+            key: "signpost.memory_average",
+            value: memoryAverage.averageMeasurement.attributeValue()
+          )
+        }
+        if let logicalWriteCount = intervalData.cumulativeLogicalWrites {
+          span.setAttribute(
+            key: "signpost.logical_write_count",
+            value: logicalWriteCount.attributeValue())
+        }
+        if #available(iOS 15.0, *) {
+          if let hitch_time_ratio = intervalData.cumulativeHitchTimeRatio {
+            span.setAttribute(
+              key: "signpost.hitch_time_ratio",
+              value: hitch_time_ratio.attributeValue()
+            )
+          }
+        }
+      }
       span.end()
     }
   }
@@ -242,11 +323,16 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
   let now = Date()
 
   // A helper for looping over the items in an optional list and logging each one.
-  func logForEach<T>(_ parent: [T]?, using closure: (T) -> [String: AttributeValueConvertable]) {
+  func logForEach<T>(
+    _ parent: [T]?, _ namespace: String, using closure: (T) -> [String: AttributeValueConvertable]
+  ) {
     if let arr = parent {
       for item in arr {
-        let attributes = closure(item).mapValues { $0.attributeValue() }
-
+        var attributes: [String: AttributeValue] = [:]
+        for (key, value) in closure(item) {
+          let namespacedKey = "metrickit.diagnostic.\(namespace).\(key)"
+          attributes[namespacedKey] = value.attributeValue()
+        }
         logger.logRecordBuilder()
           .setTimestamp(payload.timeStampEnd)
           .setObservedTimestamp(now)
@@ -257,48 +343,53 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
   }
 
   if #available(iOS 16.0, *) {
-    logForEach(payload.appLaunchDiagnostics) {
-      ["name": "app-launch", "launch-duration": $0.launchDuration.value]
+    logForEach(payload.appLaunchDiagnostics, "app_launch") {
+      [
+        "name": "app_launch",
+        "launch_duration": $0.launchDuration.value,
+      ]
     }
   }
-  logForEach(payload.diskWriteExceptionDiagnostics) {
-    ["name": "disk-write-exception", "total-writes-caused": $0.totalWritesCaused.value]
-  }
-  logForEach(payload.hangDiagnostics) {
-    ["name": "hang", "hang-duration": $0.hangDuration.value]
-  }
-  logForEach(payload.cpuExceptionDiagnostics) {
+  logForEach(payload.diskWriteExceptionDiagnostics, "disk_write_exception") {
     [
-      "name": "cpu-exception",
-      "total-cpu-time": $0.totalCPUTime,
-      "total-sampled-time": $0.totalSampledTime.value,
+      "name": "disk_write_exception",
+      "total_writes_caused": $0.totalWritesCaused.value,
     ]
   }
-  logForEach(payload.crashDiagnostics) {
+  logForEach(payload.hangDiagnostics, "hang") {
+    [
+      "name": "hang",
+      "hang_duration": $0.hangDuration.value,
+    ]
+  }
+  logForEach(payload.cpuExceptionDiagnostics, "cpu_exception") {
+    [
+      "name": "cpu_exception",
+      "total_cpu_time": $0.totalCPUTime,
+      "total_sampled_time": $0.totalSampledTime.value,
+    ]
+  }
+  logForEach(payload.crashDiagnostics, "crash") {
     var attrs: [String: AttributeValueConvertable] = ["name": "crash"]
     if let exceptionCode = $0.exceptionCode {
-      attrs["exception-code"] = exceptionCode.intValue
+      attrs["exception.code"] = exceptionCode.intValue
     }
     if let exceptionType = $0.exceptionType {
-      // Include the original field, but also the semantic convention otel equivalent.
-      attrs["exception-type"] = exceptionType.intValue
-      attrs["exception.type"] = "\(exceptionType.intValue)"
+      attrs["exception.mach_execution_type"] = exceptionType.intValue
     }
     if let signal = $0.signal {
-      attrs["signal"] = signal.intValue
+      attrs["exception.signal"] = signal.intValue
     }
     if let terminationReason = $0.terminationReason {
-      attrs["termination-reason"] = terminationReason
+      attrs["exception.termination_reason"] = terminationReason
     }
     if #available(iOS 17.0, *) {
       if let exceptionReason = $0.exceptionReason {
-        attrs["exception.type"] = exceptionReason.exceptionType
-        attrs["exception.message"] = exceptionReason.composedMessage
-
-        attrs["exception-reason-class-name"] = exceptionReason.className
-        attrs["exception-reason-composed-message"] = exceptionReason.composedMessage
-        attrs["exception-reason-exception-name"] = exceptionReason.exceptionName
-        attrs["exception-reason-exception-type"] = exceptionReason.exceptionType
+        attrs["exception.objc.type"] = exceptionReason.exceptionType
+        attrs["exception.objc.message"] = exceptionReason.composedMessage
+        attrs["exception.objc.classname"] = exceptionReason.className
+        attrs["exception.objc.message"] = exceptionReason.composedMessage
+        attrs["exception.objc.name"] = exceptionReason.exceptionName
       }
     }
     return attrs

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -130,7 +130,7 @@ func reportMetrics(payload: MXMetricPayload) {
   captureMetric(
     key: "includes_multiple_application_versions",
     value: payload.includesMultipleApplicationVersions)
-  captureMetric(key: "latest_application-version", value: payload.latestApplicationVersion)
+  captureMetric(key: "latest_application_version", value: payload.latestApplicationVersion)
   captureMetric(key: "timestamp_begin", value: payload.timeStampBegin.timeIntervalSince1970)
   captureMetric(key: "timestamp_end", value: payload.timeStampEnd.timeIntervalSince1970)
 

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -296,7 +296,6 @@ func reportMetrics(payload: MXMetricPayload) {
       span.setAttribute(key: "signpost.category", value: signpostMetric.signpostCategory)
       span.setAttribute(key: "signpost.count", value: signpostMetric.totalCount)
       if let intervalData = signpostMetric.signpostIntervalData {
-        //override var histogrammedSignpostDuration: MXHistogram<UnitDuration> {
         if let cpuTime = intervalData.cumulativeCPUTime {
           span.setAttribute(
             key: "signpost.cpu_time",
@@ -404,7 +403,6 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
         attrs["exception.objc.type"] = exceptionReason.exceptionType
         attrs["exception.objc.message"] = exceptionReason.composedMessage
         attrs["exception.objc.classname"] = exceptionReason.className
-        attrs["exception.objc.message"] = exceptionReason.composedMessage
         attrs["exception.objc.name"] = exceptionReason.exceptionName
       }
     }

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -170,7 +170,8 @@ func reportMetrics(payload: MXMetricPayload) {
   }
   withCategory(payload.locationActivityMetrics, "location_activity") {
     captureMetric(key: "best_accuracy_time", value: $0.cumulativeBestAccuracyTime)
-    captureMetric(key: "best_accuracy_for_nav_time", value: $0.cumulativeBestAccuracyForNavigationTime)
+    captureMetric(
+      key: "best_accuracy_for_nav_time", value: $0.cumulativeBestAccuracyForNavigationTime)
     captureMetric(key: "accuracy_10m_time", value: $0.cumulativeNearestTenMetersAccuracyTime)
     captureMetric(key: "accuracy_100m_time", value: $0.cumulativeHundredMetersAccuracyTime)
     captureMetric(key: "accuracy_1km_time", value: $0.cumulativeKilometerAccuracyTime)
@@ -346,7 +347,7 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
     if let arr = parent {
       for item in arr {
         var attributes: [String: AttributeValue] = [
-          "name" : "metrickit.diagnostic.\(namespace)".attributeValue()
+          "name": "metrickit.diagnostic.\(namespace)".attributeValue()
         ]
         for (key, value) in closure(item) {
           let namespacedKey = "metrickit.diagnostic.\(namespace).\(key)"
@@ -364,18 +365,18 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
   if #available(iOS 16.0, *) {
     logForEach(payload.appLaunchDiagnostics, "app_launch") {
       [
-        "launch_duration": $0.launchDuration,
+        "launch_duration": $0.launchDuration
       ]
     }
   }
   logForEach(payload.diskWriteExceptionDiagnostics, "disk_write_exception") {
     [
-      "total_writes_caused": $0.totalWritesCaused,
+      "total_writes_caused": $0.totalWritesCaused
     ]
   }
   logForEach(payload.hangDiagnostics, "hang") {
     [
-      "hang_duration": $0.hangDuration,
+      "hang_duration": $0.hangDuration
     ]
   }
   logForEach(payload.cpuExceptionDiagnostics, "cpu_exception") {

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -345,7 +345,9 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
   ) {
     if let arr = parent {
       for item in arr {
-        var attributes: [String: AttributeValue] = [:]
+        var attributes: [String: AttributeValue] = [
+          "name" : "metrickit.diagnostic.\(namespace)".attributeValue()
+        ]
         for (key, value) in closure(item) {
           let namespacedKey = "metrickit.diagnostic.\(namespace).\(key)"
           attributes[namespacedKey] = value.attributeValue()
@@ -362,32 +364,28 @@ func reportDiagnostics(payload: MXDiagnosticPayload) {
   if #available(iOS 16.0, *) {
     logForEach(payload.appLaunchDiagnostics, "app_launch") {
       [
-        "name": "app_launch",
         "launch_duration": $0.launchDuration,
       ]
     }
   }
   logForEach(payload.diskWriteExceptionDiagnostics, "disk_write_exception") {
     [
-      "name": "disk_write_exception",
       "total_writes_caused": $0.totalWritesCaused,
     ]
   }
   logForEach(payload.hangDiagnostics, "hang") {
     [
-      "name": "hang",
       "hang_duration": $0.hangDuration,
     ]
   }
   logForEach(payload.cpuExceptionDiagnostics, "cpu_exception") {
     [
-      "name": "cpu_exception",
       "total_cpu_time": $0.totalCPUTime,
       "total_sampled_time": $0.totalSampledTime,
     ]
   }
   logForEach(payload.crashDiagnostics, "crash") {
-    var attrs: [String: AttributeValueConvertable] = ["name": "crash"]
+    var attrs: [String: AttributeValueConvertable] = [:]
     if let exceptionCode = $0.exceptionCode {
       attrs["exception.code"] = exceptionCode.intValue
     }

--- a/Tests/SmokeTests/HoneycombSmokeTests.swift
+++ b/Tests/SmokeTests/HoneycombSmokeTests.swift
@@ -40,4 +40,11 @@ final class HoneycombSmokeTests: XCTestCase {
         let span = tracerProvider.spanBuilder(spanName: "test-span").startSpan()
         span.end()
     }
+  
+    func testMetricKit() throws {
+        reportMetrics(payload: FakeMetricPayload())
+        if #available(iOS 14.0, *) {
+            reportDiagnostics(payload: FakeDiagnosticPayload())
+        }
+    }
 }

--- a/Tests/SmokeTests/MetricKitTestHelpers.swift
+++ b/Tests/SmokeTests/MetricKitTestHelpers.swift
@@ -1,0 +1,63 @@
+import Foundation
+import MetricKit
+
+@testable import Honeycomb
+
+class FakeMetricPayload: MXMetricPayload {
+  private let now = Date()
+  
+  override init() {
+    super.init()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+  
+  override var latestApplicationVersion: String { "3.14.159" }
+  
+  override var includesMultipleApplicationVersions: Bool { false }
+
+  override var timeStampBegin: Date {
+    // MetricKit generally reports data from the previous day.
+    now.advanced(by: TimeInterval(-1 * 60 * 60 * 24))
+  }
+
+  override var timeStampEnd: Date { now }
+
+  override var cpuMetrics: MXCPUMetric? { get }
+
+  override var gpuMetrics: MXGPUMetric? { get }
+
+  override var cellularConditionMetrics: MXCellularConditionMetric? { get }
+
+  override var applicationTimeMetrics: MXAppRunTimeMetric? { get }
+
+  override var locationActivityMetrics: MXLocationActivityMetric? { get }
+
+  override var networkTransferMetrics: MXNetworkTransferMetric? { get }
+
+  override var applicationLaunchMetrics: MXAppLaunchMetric? { get }
+
+  override var applicationResponsivenessMetrics: MXAppResponsivenessMetric? { get }
+
+  override var diskIOMetrics: MXDiskIOMetric? { get }
+
+  override var memoryMetrics: MXMemoryMetric? { get }
+
+  override var displayMetrics: MXDisplayMetric? { get }
+
+  @available(iOS 14.0, *)
+  override var animationMetrics: MXAnimationMetric? { get }
+
+  @available(iOS 14.0, *)
+  override var applicationExitMetrics: MXAppExitMetric? { get }
+
+  override var signpostMetrics: [MXSignpostMetric]? { get }
+
+  override var metaData: MXMetaData? { get }
+}
+
+func makeFakeMetricPayload() -> MXMetricPayload {
+  FakeMetricPayload()
+}

--- a/Tests/SmokeTests/MetricKitTestHelpers.swift
+++ b/Tests/SmokeTests/MetricKitTestHelpers.swift
@@ -3,19 +3,141 @@ import MetricKit
 
 @testable import Honeycomb
 
+// Most MetricKit classes are readonly, and don't have public constructors, so to make fake data,
+// we have to subclass them. Unfortunately, Swift doesn't really have any metaprogramming
+// capability, so there is a ton of boilerplate code.
+//
+// We have to create a separate fake histogram class for each type of histogram and average,
+// because "Inheritance from a generic Objective-C class 'MXHistogramBucket' must bind type
+// parameters of 'MXHistogramBucket' to specific concrete types."
+
+class FakeDurationHistogramBucket: MXHistogramBucket<UnitDuration> {
+  private let start: Measurement<UnitDuration>
+  private let end: Measurement<UnitDuration>
+  private let count: Int
+
+  init(
+    start: Measurement<UnitDuration>,
+    end: Measurement<UnitDuration>,
+    count: Int
+  ) {
+    self.start = start
+    self.end = end
+    self.count = count
+    super.init()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var bucketStart: Measurement<UnitDuration> { start }
+  override var bucketEnd: Measurement<UnitDuration> { end }
+  override var bucketCount: Int { count }
+}
+
+class FakeDurationHistogram: MXHistogram<UnitDuration> {
+  private let average: Measurement<UnitDuration>
+
+  /** Creates a Histogram with a single bucket that will have the correct average value. */
+  init(average: Measurement<UnitDuration>) {
+    self.average = average
+    super.init()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var totalBucketCount: Int { 1 }
+
+  override var bucketEnumerator: NSEnumerator {
+    // Just make a bucket whose average will be correct.
+    let delta = average * 0.5
+    let bucket = FakeDurationHistogramBucket(start: average - delta, end: average + delta, count: 1)
+    return NSArray(object: bucket).objectEnumerator()
+  }
+}
+
+class FakeSignalBarsHistogramBucket: MXHistogramBucket<MXUnitSignalBars> {
+  private let start: Measurement<MXUnitSignalBars>
+  private let end: Measurement<MXUnitSignalBars>
+  private let count: Int
+
+  init(
+    start: Measurement<MXUnitSignalBars>,
+    end: Measurement<MXUnitSignalBars>,
+    count: Int
+  ) {
+    self.start = start
+    self.end = end
+    self.count = count
+    super.init()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var bucketStart: Measurement<MXUnitSignalBars> { start }
+  override var bucketEnd: Measurement<MXUnitSignalBars> { end }
+  override var bucketCount: Int { count }
+}
+
+class FakeSignalBarsHistogram: MXHistogram<MXUnitSignalBars> {
+  private let average: Measurement<MXUnitSignalBars>
+
+  /** Creates a Histogram with a single bucket that will have the correct average value. */
+  init(average: Measurement<MXUnitSignalBars>) {
+    self.average = average
+    super.init()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var totalBucketCount: Int { 1 }
+
+  override var bucketEnumerator: NSEnumerator {
+    // Just make a bucket whose average will be correct.
+    let delta = average * 0.5
+    let bucket = FakeSignalBarsHistogramBucket(
+      start: average - delta, end: average + delta, count: 1)
+    return NSArray(object: bucket).objectEnumerator()
+  }
+}
+
+class FakeInformationStorageAverage: MXAverage<UnitInformationStorage> {
+  private let average: Measurement<UnitInformationStorage>
+
+  init(average: Measurement<UnitInformationStorage>) {
+    self.average = average
+    super.init()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var averageMeasurement: Measurement<UnitInformationStorage> { average }
+  override var sampleCount: Int { 1 }
+  override var standardDeviation: Double { 1.0 }
+}
+
 class FakeMetricPayload: MXMetricPayload {
   private let now = Date()
-  
+
   override init() {
     super.init()
   }
-  
+
   required init?(coder: NSCoder) {
-    super.init(coder: coder)
+    fatalError("init(coder:) has not been implemented")
   }
-  
+
   override var latestApplicationVersion: String { "3.14.159" }
-  
+
   override var includesMultipleApplicationVersions: Bool { false }
 
   override var timeStampBegin: Date {
@@ -25,39 +147,366 @@ class FakeMetricPayload: MXMetricPayload {
 
   override var timeStampEnd: Date { now }
 
-  override var cpuMetrics: MXCPUMetric? { get }
+  override var cpuMetrics: MXCPUMetric? {
+    class FakeCPUMetric: MXCPUMetric {
+      override var cumulativeCPUTime: Measurement<UnitDuration> {
+        Measurement(value: 1.0, unit: UnitDuration.seconds)
+      }
 
-  override var gpuMetrics: MXGPUMetric? { get }
+      @available(iOS 14.0, *)
+      override var cumulativeCPUInstructions: Measurement<Unit> {
+        Measurement(value: 2.0, unit: Unit(symbol: "instructions"))
+      }
+    }
+    return FakeCPUMetric()
+  }
 
-  override var cellularConditionMetrics: MXCellularConditionMetric? { get }
+  override var gpuMetrics: MXGPUMetric? {
+    class FakeGPUMetric: MXGPUMetric {
+      override var cumulativeGPUTime: Measurement<UnitDuration> {
+        return Measurement(value: 3.0, unit: UnitDuration.hours)
+      }
+    }
+    return FakeGPUMetric()
+  }
 
-  override var applicationTimeMetrics: MXAppRunTimeMetric? { get }
+  override var cellularConditionMetrics: MXCellularConditionMetric? {
+    class FakeCellularConditionMetric: MXCellularConditionMetric {
+      override var histogrammedCellularConditionTime: MXHistogram<MXUnitSignalBars> {
+        FakeSignalBarsHistogram(average: Measurement(value: 4.0, unit: MXUnitSignalBars.bars))
+      }
+    }
+    return FakeCellularConditionMetric()
+  }
 
-  override var locationActivityMetrics: MXLocationActivityMetric? { get }
+  override var applicationTimeMetrics: MXAppRunTimeMetric? {
+    class FakeAppRunTimeMetric: MXAppRunTimeMetric {
+      override var cumulativeForegroundTime: Measurement<UnitDuration> {
+        Measurement(value: 5.0, unit: UnitDuration.minutes)
+      }
+      override var cumulativeBackgroundTime: Measurement<UnitDuration> {
+        Measurement(value: 6.0, unit: UnitDuration.microseconds)
+      }
+      override var cumulativeBackgroundAudioTime: Measurement<UnitDuration> {
+        Measurement(value: 7.0, unit: UnitDuration.milliseconds)
+      }
+      override var cumulativeBackgroundLocationTime: Measurement<UnitDuration> {
+        Measurement(value: 8.0, unit: UnitDuration.minutes)
+      }
+    }
+    return FakeAppRunTimeMetric()
+  }
 
-  override var networkTransferMetrics: MXNetworkTransferMetric? { get }
+  override var locationActivityMetrics: MXLocationActivityMetric? {
+    class FakeLocationActivityMetric: MXLocationActivityMetric {
+      override var cumulativeBestAccuracyTime: Measurement<UnitDuration> {
+        Measurement(value: 9.0, unit: UnitDuration.seconds)
+      }
+      override var cumulativeBestAccuracyForNavigationTime: Measurement<UnitDuration> {
+        Measurement(value: 10.0, unit: UnitDuration.seconds)
+      }
+      override var cumulativeNearestTenMetersAccuracyTime: Measurement<UnitDuration> {
+        Measurement(value: 11.0, unit: UnitDuration.seconds)
+      }
+      override var cumulativeHundredMetersAccuracyTime: Measurement<UnitDuration> {
+        Measurement(value: 12.0, unit: UnitDuration.seconds)
+      }
+      override var cumulativeKilometerAccuracyTime: Measurement<UnitDuration> {
+        Measurement(value: 13.0, unit: UnitDuration.seconds)
+      }
+      override var cumulativeThreeKilometersAccuracyTime: Measurement<UnitDuration> {
+        Measurement(value: 14.0, unit: UnitDuration.seconds)
+      }
+    }
+    return FakeLocationActivityMetric()
+  }
 
-  override var applicationLaunchMetrics: MXAppLaunchMetric? { get }
+  override var networkTransferMetrics: MXNetworkTransferMetric? {
+    class FakeNetworkTransferMetric: MXNetworkTransferMetric {
+      override var cumulativeWifiUpload: Measurement<UnitInformationStorage> {
+        Measurement(value: 15.0, unit: UnitInformationStorage.bytes)
+      }
+      override var cumulativeWifiDownload: Measurement<UnitInformationStorage> {
+        Measurement(value: 16.0, unit: UnitInformationStorage.kilobytes)
+      }
+      override var cumulativeCellularUpload: Measurement<UnitInformationStorage> {
+        Measurement(value: 17.0, unit: UnitInformationStorage.megabytes)
+      }
+      override var cumulativeCellularDownload: Measurement<UnitInformationStorage> {
+        Measurement(value: 18.0, unit: UnitInformationStorage.gigabytes)
+      }
+    }
+    return FakeNetworkTransferMetric()
+  }
 
-  override var applicationResponsivenessMetrics: MXAppResponsivenessMetric? { get }
+  override var applicationLaunchMetrics: MXAppLaunchMetric? {
+    class FakeAppLaunchMetric: MXAppLaunchMetric {
+      override var histogrammedTimeToFirstDraw: MXHistogram<UnitDuration> {
+        FakeDurationHistogram(average: Measurement(value: 19.0, unit: UnitDuration.minutes))
+      }
+      override var histogrammedApplicationResumeTime: MXHistogram<UnitDuration> {
+        FakeDurationHistogram(average: Measurement(value: 20.0, unit: UnitDuration.minutes))
+      }
 
-  override var diskIOMetrics: MXDiskIOMetric? { get }
+      @available(iOS 15.2, *)
+      override var histogrammedOptimizedTimeToFirstDraw: MXHistogram<UnitDuration> {
+        FakeDurationHistogram(average: Measurement(value: 21.0, unit: UnitDuration.minutes))
+      }
 
-  override var memoryMetrics: MXMemoryMetric? { get }
+      @available(iOS 16.0, *)
+      override var histogrammedExtendedLaunch: MXHistogram<UnitDuration> {
+        FakeDurationHistogram(average: Measurement(value: 22.0, unit: UnitDuration.minutes))
+      }
+    }
+    return FakeAppLaunchMetric()
+  }
 
-  override var displayMetrics: MXDisplayMetric? { get }
+  override var applicationResponsivenessMetrics: MXAppResponsivenessMetric? {
+    class FakeAppResponsivenessMetric: MXAppResponsivenessMetric {
+      override var histogrammedApplicationHangTime: MXHistogram<UnitDuration> {
+        FakeDurationHistogram(average: Measurement(value: 23.0, unit: UnitDuration.hours))
+      }
+    }
+    return FakeAppResponsivenessMetric()
+  }
+
+  override var diskIOMetrics: MXDiskIOMetric? {
+    class FakeDiskIOMetric: MXDiskIOMetric {
+      override var cumulativeLogicalWrites: Measurement<UnitInformationStorage> {
+        Measurement(value: 24.0, unit: UnitInformationStorage.terabytes)
+      }
+    }
+    return FakeDiskIOMetric()
+  }
+
+  override var memoryMetrics: MXMemoryMetric? {
+    class FakeMemoryMetric: MXMemoryMetric {
+      override var peakMemoryUsage: Measurement<UnitInformationStorage> {
+        Measurement(value: 25.0, unit: UnitInformationStorage.bytes)
+      }
+      override var averageSuspendedMemory: MXAverage<UnitInformationStorage> {
+        FakeInformationStorageAverage(
+          average: Measurement(value: 26.0, unit: UnitInformationStorage.bytes))
+      }
+    }
+    return FakeMemoryMetric()
+  }
+
+  override var displayMetrics: MXDisplayMetric? {
+    class FakePixelLuminanceAverage: MXAverage<MXUnitAveragePixelLuminance> {
+      override var averageMeasurement: Measurement<MXUnitAveragePixelLuminance> {
+        Measurement(value: 27.0, unit: MXUnitAveragePixelLuminance.apl)
+      }
+      override var sampleCount: Int { 1 }
+      override var standardDeviation: Double { 1.0 }
+    }
+    class FakeDisplayMetric: MXDisplayMetric {
+      override var averagePixelLuminance: MXAverage<MXUnitAveragePixelLuminance>? {
+        FakePixelLuminanceAverage()
+      }
+    }
+    return FakeDisplayMetric()
+  }
 
   @available(iOS 14.0, *)
-  override var animationMetrics: MXAnimationMetric? { get }
+  override var animationMetrics: MXAnimationMetric? {
+    class FakeAnimationMetric: MXAnimationMetric {
+      override var scrollHitchTimeRatio: Measurement<Unit> {
+        Measurement(value: 28.0, unit: Unit(symbol: "ratio"))
+      }
+    }
+    return FakeAnimationMetric()
+  }
+
+  override var metaData: MXMetaData? {
+    class FakeMetaData: MXMetaData {
+      override var regionFormat: String { "format" }
+      override var osVersion: String { "os" }
+      override var deviceType: String { "device" }
+      override var applicationBuildVersion: String { "build" }
+
+      @available(iOS 14.0, *)
+      override var platformArchitecture: String { "arch" }
+
+      @available(iOS 17.0, *)
+      override var lowPowerModeEnabled: Bool { true }
+
+      @available(iOS 17.0, *)
+      override var isTestFlightApp: Bool { true }
+
+      @available(iOS 17.0, *)
+      override var pid: pid_t { 29 }
+    }
+    return FakeMetaData()
+  }
 
   @available(iOS 14.0, *)
-  override var applicationExitMetrics: MXAppExitMetric? { get }
+  override var applicationExitMetrics: MXAppExitMetric? {
+    class FakeAppExitMetric: MXAppExitMetric {
+      override var foregroundExitData: MXForegroundExitData {
+        class FakeForegroundExitData: MXForegroundExitData {
+          override var cumulativeNormalAppExitCount: Int { 30 }
+          override var cumulativeMemoryResourceLimitExitCount: Int { 31 }
+          override var cumulativeBadAccessExitCount: Int { 32 }
+          override var cumulativeAbnormalExitCount: Int { 33 }
+          override var cumulativeIllegalInstructionExitCount: Int { 34 }
+          override var cumulativeAppWatchdogExitCount: Int { 35 }
+        }
+        return FakeForegroundExitData()
+      }
 
-  override var signpostMetrics: [MXSignpostMetric]? { get }
+      override var backgroundExitData: MXBackgroundExitData {
+        class FakeBackgroundExitData: MXBackgroundExitData {
+          override var cumulativeNormalAppExitCount: Int { 36 }
+          override var cumulativeMemoryResourceLimitExitCount: Int { 37 }
+          override var cumulativeCPUResourceLimitExitCount: Int { 38 }
+          override var cumulativeMemoryPressureExitCount: Int { 39 }
+          override var cumulativeBadAccessExitCount: Int { 40 }
+          override var cumulativeAbnormalExitCount: Int { 41 }
+          override var cumulativeIllegalInstructionExitCount: Int { 42 }
+          override var cumulativeAppWatchdogExitCount: Int { 43 }
+          override var cumulativeSuspendedWithLockedFileExitCount: Int { 44 }
+          override var cumulativeBackgroundTaskAssertionTimeoutExitCount: Int { 45 }
+        }
+        return FakeBackgroundExitData()
+      }
+    }
+    return FakeAppExitMetric()
+  }
 
-  override var metaData: MXMetaData? { get }
+  override var signpostMetrics: [MXSignpostMetric]? {
+    class FakeSignpostIntervalData: MXSignpostIntervalData {
+      override var histogrammedSignpostDuration: MXHistogram<UnitDuration> {
+        FakeDurationHistogram(average: Measurement(value: 46.0, unit: UnitDuration.seconds))
+      }
+      override var cumulativeCPUTime: Measurement<UnitDuration>? {
+        Measurement(value: 47.0, unit: UnitDuration.seconds)
+      }
+      override var averageMemory: MXAverage<UnitInformationStorage>? {
+        FakeInformationStorageAverage(
+          average: Measurement(value: 48.0, unit: UnitInformationStorage.bytes))
+      }
+      override var cumulativeLogicalWrites: Measurement<UnitInformationStorage>? {
+        Measurement(value: 49.0, unit: UnitInformationStorage.bytes)
+      }
+
+      @available(iOS 15.0, *)
+      override var cumulativeHitchTimeRatio: Measurement<Unit>? {
+        Measurement(value: 50.0, unit: Unit(symbol: "ratio"))
+      }
+    }
+
+    class FakeSignpostMetric: MXSignpostMetric {
+      private let name: String
+      private let category: String
+      private let count: Int
+
+      init(name: String, category: String, count: Int) {
+        self.name = name
+        self.category = category
+        self.count = count
+        super.init()
+      }
+
+      required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+      }
+
+      override var signpostName: String { name }
+      override var signpostCategory: String { category }
+      override var signpostIntervalData: MXSignpostIntervalData? { FakeSignpostIntervalData() }
+      override var totalCount: Int { count }
+    }
+    return [
+      FakeSignpostMetric(name: "signpost1", category: "cat1", count: 51),
+      FakeSignpostMetric(name: "signpost2", category: "cat2", count: 52),
+    ]
+  }
 }
 
-func makeFakeMetricPayload() -> MXMetricPayload {
-  FakeMetricPayload()
+@available(iOS 14.0, *)
+class FakeCallStackTree: MXCallStackTree {
+}
+
+@available(iOS 14.0, *)
+class FakeDiagnosticPayload: MXDiagnosticPayload {
+  private let now = Date()
+
+  override var timeStampBegin: Date {
+    // MetricKit generally reports data from the previous day.
+    now.advanced(by: TimeInterval(-1 * 60 * 60 * 24))
+  }
+
+  override var timeStampEnd: Date { now }
+
+  override var cpuExceptionDiagnostics: [MXCPUExceptionDiagnostic]? {
+    class FakeCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
+      override var callStackTree: MXCallStackTree { FakeCallStackTree() }
+      override var totalCPUTime: Measurement<UnitDuration> {
+        Measurement(value: 53.0, unit: UnitDuration.minutes)
+      }
+      override var totalSampledTime: Measurement<UnitDuration> {
+        Measurement(value: 54.0, unit: UnitDuration.hours)
+      }
+    }
+    return [FakeCPUExceptionDiagnostic()]
+  }
+
+  override var diskWriteExceptionDiagnostics: [MXDiskWriteExceptionDiagnostic]? {
+    class FakeDiskWriteExceptionDiagnostic: MXDiskWriteExceptionDiagnostic {
+      override var callStackTree: MXCallStackTree { FakeCallStackTree() }
+      override var totalWritesCaused: Measurement<UnitInformationStorage> {
+        Measurement(value: 55.0, unit: UnitInformationStorage.megabytes)
+      }
+    }
+    return [FakeDiskWriteExceptionDiagnostic()]
+  }
+
+  override var hangDiagnostics: [MXHangDiagnostic]? {
+    class FakeHangDiagnostic: MXHangDiagnostic {
+      override var callStackTree: MXCallStackTree { FakeCallStackTree() }
+      override var hangDuration: Measurement<UnitDuration> {
+        Measurement(value: 56.0, unit: UnitDuration.seconds)
+      }
+    }
+    return [FakeHangDiagnostic()]
+  }
+
+  override var crashDiagnostics: [MXCrashDiagnostic]? {
+    class FakeCrashDiagnostic: MXCrashDiagnostic {
+      override var callStackTree: MXCallStackTree { FakeCallStackTree() }
+      override var terminationReason: String? { "reason" }
+      override var virtualMemoryRegionInfo: String? { nil }
+      override var exceptionType: NSNumber? { NSNumber(integerLiteral: 57) }
+      override var exceptionCode: NSNumber? { NSNumber(integerLiteral: 58) }
+      override var signal: NSNumber? { NSNumber(integerLiteral: 59) }
+
+      @available(iOS 17.0, *)
+      override var exceptionReason: MXCrashDiagnosticObjectiveCExceptionReason? {
+        class FakeCrashDiagnosticObjectiveCExceptionReason:
+          MXCrashDiagnosticObjectiveCExceptionReason
+        {
+          override var composedMessage: String { "message: 1 2" }
+          override var formatString: String { "message: %d %d" }
+          override var arguments: [String] { ["1", "2"] }
+          override var exceptionType: String { "ExceptionType" }
+          override var className: String { "MyClass" }
+          override var exceptionName: String { "MyCrash" }
+        }
+        return FakeCrashDiagnosticObjectiveCExceptionReason()
+      }
+    }
+    return [FakeCrashDiagnostic()]
+  }
+
+  @available(iOS 16.0, *)
+  override var appLaunchDiagnostics: [MXAppLaunchDiagnostic]? {
+    class FakeAppLaunchDiagnostic: MXAppLaunchDiagnostic {
+      override var callStackTree: MXCallStackTree { FakeCallStackTree() }
+      override var launchDuration: Measurement<UnitDuration> {
+        Measurement(value: 60.0, unit: UnitDuration.seconds)
+      }
+    }
+    return [FakeAppLaunchDiagnostic()]
+  }
 }

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -22,3 +22,7 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [file, logging]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file, logging]

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -104,7 +104,7 @@ mk_attr() {
 #   $1 - attribute key
 #   $2 - attribute type
 mk_diag_attr() {
-  scope="@honeycombio/instrumentation-metric-kit-diagnostics"
+  scope="@honeycombio/instrumentation-metric-kit"
   attribute_for_log_key $scope $1 $2
 }
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -17,3 +17,84 @@ teardown_file() {
   assert_equal "$result" '"test-span"'
 }
 
+# A helper just for MetricKit attributes, because there's so many of them.
+# Arguments:
+#   $1 - attribute key
+#   $2 - attribute type
+mkattr() {
+  scope="@honeycombio/instrumentation-metric-kit"
+  span="MXMetricPayload"
+  attribute_for_key $scope $span $1 $2
+}
+
+@test "MetricKit values are present and units are converted" {
+  assert_equal "$(mkattr "metrickit.includes_multiple_application_versions" bool)" false
+  assert_equal "$(mkattr "metrickit.latest_application-version" string)" '"3.14.159"'
+  assert_equal "$(mkattr "metrickit.cpu.cpu_time" double)" 1
+  assert_equal "$(mkattr "metrickit.cpu.instruction_count" double)" 2
+  assert_equal "$(mkattr "metrickit.gpu.time" double)" 10800  # 3 hours
+  assert_equal "$(mkattr "metrickit.cellular_condition.bars_average" double)" 4
+  assert_equal "$(mkattr "metrickit.app_time.foreground_time" double)" 300          # 5 minutes
+  assert_equal "$(mkattr "metrickit.app_time.background_time" double)" 0.000006     # 6 microseconds
+  assert_equal "$(mkattr "metrickit.app_time.background_audio_time" double)" 0.007  # 7 milliseconds
+  assert_equal "$(mkattr "metrickit.app_time.background_location_time" double)" 480 # 8 minutes
+  assert_equal "$(mkattr "metrickit.location_activity.best_accuracy_time" double)" 9
+  assert_equal "$(mkattr "metrickit.location_activity.best_accuracy_for_nav_time" double)" 10
+  assert_equal "$(mkattr "metrickit.location_activity.accuracy_10m_time" double)"  11
+  assert_equal "$(mkattr "metrickit.location_activity.accuracy_100m_time" double)" 12
+  assert_equal "$(mkattr "metrickit.location_activity.accuracy_1km_time" double)" 13
+  assert_equal "$(mkattr "metrickit.location_activity.accuracy_3km_time" double)" 14
+  assert_equal "$(mkattr "metrickit.network_transfer.wifi_upload" double)" 15                 # 15 B
+  assert_equal "$(mkattr "metrickit.network_transfer.wifi_download" double)" 16000            # 16 KB
+  assert_equal "$(mkattr "metrickit.network_transfer.cellular_upload" double)" 17000000       # 17 MB
+  assert_equal "$(mkattr "metrickit.network_transfer.cellular_download" double)" 18000000000  # 18 GB
+  assert_equal "$(mkattr "metrickit.app_launch.time_to_first_draw_average" double)" 1140            # 19 minutes
+  assert_equal "$(mkattr "metrickit.app_launch.app_resume_time_average" double)" 1200               # 20 minutes
+  assert_equal "$(mkattr "metrickit.app_launch.optimized_time_to_first_draw_average" double)" 1260  # 21 minutes
+  assert_equal "$(mkattr "metrickit.app_launch.extended_launch_average" double)" 1320               # 22 minutes
+  assert_equal "$(mkattr "metrickit.app_responsiveness.hang_time_average" double)" 82800  # 23 hours
+  assert_equal "$(mkattr "metrickit.diskio.logical_write_count" double)" 24000000000000  # 24 TB
+  assert_equal "$(mkattr "metrickit.memory.peak_memory_usage" double)" 25
+  assert_equal "$(mkattr "metrickit.memory.suspended_memory_average" double)" 26
+  assert_equal "$(mkattr "metrickit.display.pixel_luminance_average" double)" 27
+  assert_equal "$(mkattr "metrickit.animation.scroll_hitch_time_ratio" double)" 28
+  assert_equal "$(mkattr "metrickit.metadata.pid" int)" '"29"'
+  assert_equal "$(mkattr "metrickit.metadata.app_build_version" string)" '"build"'
+  assert_equal "$(mkattr "metrickit.metadata.device_type" string)" '"device"'
+  assert_equal "$(mkattr "metrickit.metadata.is_test_flight_app" bool)" true
+  assert_equal "$(mkattr "metrickit.metadata.low_power_mode_enabled" bool)" true
+  assert_equal "$(mkattr "metrickit.metadata.os_version" string)" '"os"'
+  assert_equal "$(mkattr "metrickit.metadata.platform_arch" string)" '"arch"'
+  assert_equal "$(mkattr "metrickit.metadata.region_format" string)" '"format"'
+  assert_equal "$(mkattr "metrickit.app_exit.foreground.normal_app_exit_count" int)" '"30"'
+  assert_equal "$(mkattr "metrickit.app_exit.foreground.memory_resource_limit_exit-count" int)" '"31"'
+  assert_equal "$(mkattr "metrickit.app_exit.foreground.bad_access_exit_count" int)" '"32"'
+  assert_equal "$(mkattr "metrickit.app_exit.foreground.abnormal_exit_count" int)" '"33"'
+  assert_equal "$(mkattr "metrickit.app_exit.foreground.illegal_instruction_exit_count" int)" '"34"'
+  assert_equal "$(mkattr "metrickit.app_exit.foreground.app_watchdog_exit_count" int)" '"35"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.normal_app_exit_count" int)" '"36"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.memory_resource_limit_exit_count" int)" '"37"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.cpu_resource_limit_exit_count" int)" '"38"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.memory_pressure_exit_count" int)" '"39"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.bad_access-exit_count" int)" '"40"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.abnormal_exit_count" int)" '"41"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.illegal_instruction_exit_count" int)" '"42"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.app_watchdog_exit_count" int)" '"43"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.suspended_with_locked_file_exit_count" int)" '"44"'
+  assert_equal "$(mkattr "metrickit.app_exit.background.background_task_assertion_timeout_exit_count" int)" '"45"'
+}
+
+@test "MXSignpostMetric data is present" {
+  scope="@honeycombio/instrumentation-metric-kit"
+  span="MXSignpostMetric"
+
+  result=$(attributes_from_span_named $scope $span | jq .key | sort | uniq)
+
+   assert_equal "$result" '"signpost.category"
+"signpost.count"
+"signpost.cpu_time"
+"signpost.hitch_time_ratio"
+"signpost.logical_write_count"
+"signpost.memory_average"
+"signpost.name"'
+}

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -29,7 +29,7 @@ mk_attr() {
 
 @test "MetricKit values are present and units are converted" {
   assert_equal "$(mk_attr "metrickit.includes_multiple_application_versions" bool)" false
-  assert_equal "$(mk_attr "metrickit.latest_application-version" string)" '"3.14.159"'
+  assert_equal "$(mk_attr "metrickit.latest_application_version" string)" '"3.14.159"'
   assert_equal "$(mk_attr "metrickit.cpu.cpu_time" double)" 1
   assert_equal "$(mk_attr "metrickit.cpu.instruction_count" double)" 2
   assert_equal "$(mk_attr "metrickit.gpu.time" double)" 10800  # 3 hours

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -21,67 +21,67 @@ teardown_file() {
 # Arguments:
 #   $1 - attribute key
 #   $2 - attribute type
-mkattr() {
+mk_attr() {
   scope="@honeycombio/instrumentation-metric-kit"
   span="MXMetricPayload"
-  attribute_for_key $scope $span $1 $2
+  attribute_for_span_key $scope $span $1 $2
 }
 
 @test "MetricKit values are present and units are converted" {
-  assert_equal "$(mkattr "metrickit.includes_multiple_application_versions" bool)" false
-  assert_equal "$(mkattr "metrickit.latest_application-version" string)" '"3.14.159"'
-  assert_equal "$(mkattr "metrickit.cpu.cpu_time" double)" 1
-  assert_equal "$(mkattr "metrickit.cpu.instruction_count" double)" 2
-  assert_equal "$(mkattr "metrickit.gpu.time" double)" 10800  # 3 hours
-  assert_equal "$(mkattr "metrickit.cellular_condition.bars_average" double)" 4
-  assert_equal "$(mkattr "metrickit.app_time.foreground_time" double)" 300          # 5 minutes
-  assert_equal "$(mkattr "metrickit.app_time.background_time" double)" 0.000006     # 6 microseconds
-  assert_equal "$(mkattr "metrickit.app_time.background_audio_time" double)" 0.007  # 7 milliseconds
-  assert_equal "$(mkattr "metrickit.app_time.background_location_time" double)" 480 # 8 minutes
-  assert_equal "$(mkattr "metrickit.location_activity.best_accuracy_time" double)" 9
-  assert_equal "$(mkattr "metrickit.location_activity.best_accuracy_for_nav_time" double)" 10
-  assert_equal "$(mkattr "metrickit.location_activity.accuracy_10m_time" double)"  11
-  assert_equal "$(mkattr "metrickit.location_activity.accuracy_100m_time" double)" 12
-  assert_equal "$(mkattr "metrickit.location_activity.accuracy_1km_time" double)" 13
-  assert_equal "$(mkattr "metrickit.location_activity.accuracy_3km_time" double)" 14
-  assert_equal "$(mkattr "metrickit.network_transfer.wifi_upload" double)" 15                 # 15 B
-  assert_equal "$(mkattr "metrickit.network_transfer.wifi_download" double)" 16000            # 16 KB
-  assert_equal "$(mkattr "metrickit.network_transfer.cellular_upload" double)" 17000000       # 17 MB
-  assert_equal "$(mkattr "metrickit.network_transfer.cellular_download" double)" 18000000000  # 18 GB
-  assert_equal "$(mkattr "metrickit.app_launch.time_to_first_draw_average" double)" 1140            # 19 minutes
-  assert_equal "$(mkattr "metrickit.app_launch.app_resume_time_average" double)" 1200               # 20 minutes
-  assert_equal "$(mkattr "metrickit.app_launch.optimized_time_to_first_draw_average" double)" 1260  # 21 minutes
-  assert_equal "$(mkattr "metrickit.app_launch.extended_launch_average" double)" 1320               # 22 minutes
-  assert_equal "$(mkattr "metrickit.app_responsiveness.hang_time_average" double)" 82800  # 23 hours
-  assert_equal "$(mkattr "metrickit.diskio.logical_write_count" double)" 24000000000000  # 24 TB
-  assert_equal "$(mkattr "metrickit.memory.peak_memory_usage" double)" 25
-  assert_equal "$(mkattr "metrickit.memory.suspended_memory_average" double)" 26
-  assert_equal "$(mkattr "metrickit.display.pixel_luminance_average" double)" 27
-  assert_equal "$(mkattr "metrickit.animation.scroll_hitch_time_ratio" double)" 28
-  assert_equal "$(mkattr "metrickit.metadata.pid" int)" '"29"'
-  assert_equal "$(mkattr "metrickit.metadata.app_build_version" string)" '"build"'
-  assert_equal "$(mkattr "metrickit.metadata.device_type" string)" '"device"'
-  assert_equal "$(mkattr "metrickit.metadata.is_test_flight_app" bool)" true
-  assert_equal "$(mkattr "metrickit.metadata.low_power_mode_enabled" bool)" true
-  assert_equal "$(mkattr "metrickit.metadata.os_version" string)" '"os"'
-  assert_equal "$(mkattr "metrickit.metadata.platform_arch" string)" '"arch"'
-  assert_equal "$(mkattr "metrickit.metadata.region_format" string)" '"format"'
-  assert_equal "$(mkattr "metrickit.app_exit.foreground.normal_app_exit_count" int)" '"30"'
-  assert_equal "$(mkattr "metrickit.app_exit.foreground.memory_resource_limit_exit-count" int)" '"31"'
-  assert_equal "$(mkattr "metrickit.app_exit.foreground.bad_access_exit_count" int)" '"32"'
-  assert_equal "$(mkattr "metrickit.app_exit.foreground.abnormal_exit_count" int)" '"33"'
-  assert_equal "$(mkattr "metrickit.app_exit.foreground.illegal_instruction_exit_count" int)" '"34"'
-  assert_equal "$(mkattr "metrickit.app_exit.foreground.app_watchdog_exit_count" int)" '"35"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.normal_app_exit_count" int)" '"36"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.memory_resource_limit_exit_count" int)" '"37"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.cpu_resource_limit_exit_count" int)" '"38"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.memory_pressure_exit_count" int)" '"39"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.bad_access-exit_count" int)" '"40"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.abnormal_exit_count" int)" '"41"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.illegal_instruction_exit_count" int)" '"42"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.app_watchdog_exit_count" int)" '"43"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.suspended_with_locked_file_exit_count" int)" '"44"'
-  assert_equal "$(mkattr "metrickit.app_exit.background.background_task_assertion_timeout_exit_count" int)" '"45"'
+  assert_equal "$(mk_attr "metrickit.includes_multiple_application_versions" bool)" false
+  assert_equal "$(mk_attr "metrickit.latest_application-version" string)" '"3.14.159"'
+  assert_equal "$(mk_attr "metrickit.cpu.cpu_time" double)" 1
+  assert_equal "$(mk_attr "metrickit.cpu.instruction_count" double)" 2
+  assert_equal "$(mk_attr "metrickit.gpu.time" double)" 10800  # 3 hours
+  assert_equal "$(mk_attr "metrickit.cellular_condition.bars_average" double)" 4
+  assert_equal "$(mk_attr "metrickit.app_time.foreground_time" double)" 300          # 5 minutes
+  assert_equal "$(mk_attr "metrickit.app_time.background_time" double)" 0.000006     # 6 microseconds
+  assert_equal "$(mk_attr "metrickit.app_time.background_audio_time" double)" 0.007  # 7 milliseconds
+  assert_equal "$(mk_attr "metrickit.app_time.background_location_time" double)" 480 # 8 minutes
+  assert_equal "$(mk_attr "metrickit.location_activity.best_accuracy_time" double)" 9
+  assert_equal "$(mk_attr "metrickit.location_activity.best_accuracy_for_nav_time" double)" 10
+  assert_equal "$(mk_attr "metrickit.location_activity.accuracy_10m_time" double)"  11
+  assert_equal "$(mk_attr "metrickit.location_activity.accuracy_100m_time" double)" 12
+  assert_equal "$(mk_attr "metrickit.location_activity.accuracy_1km_time" double)" 13
+  assert_equal "$(mk_attr "metrickit.location_activity.accuracy_3km_time" double)" 14
+  assert_equal "$(mk_attr "metrickit.network_transfer.wifi_upload" double)" 15                 # 15 B
+  assert_equal "$(mk_attr "metrickit.network_transfer.wifi_download" double)" 16000            # 16 KB
+  assert_equal "$(mk_attr "metrickit.network_transfer.cellular_upload" double)" 17000000       # 17 MB
+  assert_equal "$(mk_attr "metrickit.network_transfer.cellular_download" double)" 18000000000  # 18 GB
+  assert_equal "$(mk_attr "metrickit.app_launch.time_to_first_draw_average" double)" 1140            # 19 minutes
+  assert_equal "$(mk_attr "metrickit.app_launch.app_resume_time_average" double)" 1200               # 20 minutes
+  assert_equal "$(mk_attr "metrickit.app_launch.optimized_time_to_first_draw_average" double)" 1260  # 21 minutes
+  assert_equal "$(mk_attr "metrickit.app_launch.extended_launch_average" double)" 1320               # 22 minutes
+  assert_equal "$(mk_attr "metrickit.app_responsiveness.hang_time_average" double)" 82800  # 23 hours
+  assert_equal "$(mk_attr "metrickit.diskio.logical_write_count" double)" 24000000000000  # 24 TB
+  assert_equal "$(mk_attr "metrickit.memory.peak_memory_usage" double)" 25
+  assert_equal "$(mk_attr "metrickit.memory.suspended_memory_average" double)" 26
+  assert_equal "$(mk_attr "metrickit.display.pixel_luminance_average" double)" 27
+  assert_equal "$(mk_attr "metrickit.animation.scroll_hitch_time_ratio" double)" 28
+  assert_equal "$(mk_attr "metrickit.metadata.pid" int)" '"29"'
+  assert_equal "$(mk_attr "metrickit.metadata.app_build_version" string)" '"build"'
+  assert_equal "$(mk_attr "metrickit.metadata.device_type" string)" '"device"'
+  assert_equal "$(mk_attr "metrickit.metadata.is_test_flight_app" bool)" true
+  assert_equal "$(mk_attr "metrickit.metadata.low_power_mode_enabled" bool)" true
+  assert_equal "$(mk_attr "metrickit.metadata.os_version" string)" '"os"'
+  assert_equal "$(mk_attr "metrickit.metadata.platform_arch" string)" '"arch"'
+  assert_equal "$(mk_attr "metrickit.metadata.region_format" string)" '"format"'
+  assert_equal "$(mk_attr "metrickit.app_exit.foreground.normal_app_exit_count" int)" '"30"'
+  assert_equal "$(mk_attr "metrickit.app_exit.foreground.memory_resource_limit_exit-count" int)" '"31"'
+  assert_equal "$(mk_attr "metrickit.app_exit.foreground.bad_access_exit_count" int)" '"32"'
+  assert_equal "$(mk_attr "metrickit.app_exit.foreground.abnormal_exit_count" int)" '"33"'
+  assert_equal "$(mk_attr "metrickit.app_exit.foreground.illegal_instruction_exit_count" int)" '"34"'
+  assert_equal "$(mk_attr "metrickit.app_exit.foreground.app_watchdog_exit_count" int)" '"35"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.normal_app_exit_count" int)" '"36"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.memory_resource_limit_exit_count" int)" '"37"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.cpu_resource_limit_exit_count" int)" '"38"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.memory_pressure_exit_count" int)" '"39"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.bad_access-exit_count" int)" '"40"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.abnormal_exit_count" int)" '"41"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.illegal_instruction_exit_count" int)" '"42"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.app_watchdog_exit_count" int)" '"43"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.suspended_with_locked_file_exit_count" int)" '"44"'
+  assert_equal "$(mk_attr "metrickit.app_exit.background.background_task_assertion_timeout_exit_count" int)" '"45"'
 }
 
 @test "MXSignpostMetric data is present" {
@@ -97,4 +97,29 @@ mkattr() {
 "signpost.logical_write_count"
 "signpost.memory_average"
 "signpost.name"'
+}
+
+# A helper just for MetricKit /diagnostic/ attributes, because there's so many of them.
+# Arguments:
+#   $1 - attribute key
+#   $2 - attribute type
+mk_diag_attr() {
+  scope="@honeycombio/instrumentation-metric-kit-diagnostics"
+  attribute_for_log_key $scope $1 $2
+}
+
+@test "MetricKit diagnostic values are present and units are converted" {
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.cpu_exception.total_cpu_time" double)" 3180        # 53 minutes
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.cpu_exception.total_sampled_time" double)" 194400  # 54 hours
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.disk_write_exception.total_writes_caused" double)" 55000000  # 55 MB
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.hang.hang_duration" double)" 56
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.mach_execution_type" int)" '"57"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.code" int)" '"58"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.signal" int)" '"59"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.objc.message" string)" '"message: 1 2"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.objc.type" string)" '"ExceptionType"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.termination_reason" string)" '"reason"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.objc.name" string)" '"MyCrash"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.objc.classname" string)" '"MyClass"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.app_launch.launch_duration" double)" 60
 }

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -13,6 +13,27 @@ span_attributes_for() {
 		jq ".attributes[]"
 }
 
+# A single attribute
+# Arguments:
+#   $1 - scope
+#   $2 - span name
+#   $3 - attribute key
+#   $4 - attribute type
+attribute_for_key() {
+	attributes_from_span_named $1 $2 | \
+		jq "select (.key == \"$3\").value" | \
+		jq ".${4}Value"
+}
+
+# All attributes from a span
+# Arguments:
+#   $1 - scope
+#   $2 - span name
+attributes_from_span_named() {
+	spans_from_scope_named $1 | \
+		jq "select (.name == \"$2\").attributes[]"
+}
+
 # All resource attributes
 resource_attributes_received() {
 	spans_received | jq ".resource.attributes[]?"

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -13,16 +13,28 @@ span_attributes_for() {
 		jq ".attributes[]"
 }
 
-# A single attribute
+# A single span attribute
 # Arguments:
 #   $1 - scope
 #   $2 - span name
 #   $3 - attribute key
 #   $4 - attribute type
-attribute_for_key() {
+attribute_for_span_key() {
 	attributes_from_span_named $1 $2 | \
 		jq "select (.key == \"$3\").value" | \
 		jq ".${4}Value"
+}
+
+# A single log attribute
+# Arguments:
+#   $1 - scope
+#   $2 - attribute key
+#   $3 - attribute type
+attribute_for_log_key() {
+	logs_from_scope_named $1 | \
+		jq ".attributes[]" | \
+		jq "select (.key == \"$2\").value" | \
+		jq ".${3}Value"
 }
 
 # All attributes from a span
@@ -45,9 +57,20 @@ spans_from_scope_named() {
 	spans_received | jq ".scopeSpans[] | select(.scope.name == \"$1\").spans[]"
 }
 
+# Logs for a given scope
+# Arguments: $1 - scope name
+logs_from_scope_named() {
+	logs_received | jq ".scopeLogs[] | select(.scope.name == \"$1\").logRecords[]"
+}
+
 # All spans received
 spans_received() {
 	jq ".resourceSpans[]?" ./collector/data.json
+}
+
+# All logs received
+logs_received() {
+	jq ".resourceLogs[]?" ./collector/data.json
 }
 
 # ASSERTION HELPERS


### PR DESCRIPTION
## Which problem is this PR solving?

This adds MetricKit signals to the Honeycomb Swift SDK.

## Short description of the changes

This adds all of the data from Apple's MetricKit into Honeycomb. It's not obvious how to structure this data in order to best fit OTel semantics conventions while also being most usable in Honeycomb. I made my best guess how to do it, but would appreciate feedback on it. I am really not sure if this is the best way to represent this data. Here is how I'm structuring the data:

### MetricKit

MetricKit reports a batch of data approximately once a day, with cumulative data from the previous day. There are two big categories of data: _Metrics_ and _Diagnostics_. These are covered below.

All of this data is captured using the scope `"@honeycombio/instrumentation-metric-kit"`

### Units

MetricKit measurements have units, so that a metric might report "1 kb" or "3 hours". To represent this data in attributes, they are all converted to the standard unit for their type (such as bytes or seconds) and represented as doubles.

### Metrics

Metrics are things like "total cpu time" and "number of abnormal exists". They are pre-aggregated over the reported period. For metrics, we report a single `Span` named `"MXMetricPayload"`. The start time of the span is the start of the reporting period, and the end of the span is the end time of the reporting period. So these spans are generally 24 hours long. Each metric is included as an attribute on that span. The attributes are namespaced corresponding to their category in `MXMetricPayload`. For example, the metrics mentioned above are named `metrickit.app_exit.foreground.abnormal_exit_count` and `metrickit.cpu.cpu_time`. For histogram data, we include only the estimated average value for now.

I used an OTel span instead of OTel metrics for a few reasons:
* Metrics usually go into a different dataset, and we want all the data in one place for a launchpad.
* The data is pre-aggregated, not individual values, so some of the OTel metric semantics don't make sense.
* The time the data is reported doesn't accurately reflect when the events occur. For example, we don't want to interpret 1000 cpu instructions over 24 hours as sitting idle for 23.999 hours and then suddenly bursting 1000 instructions.
* The Swift metrics APIs are confusing, and it's not clear how to represent some of the data.

We could add OTel metrics later too, if we want to.

### Diagnostics

Diagnostics are events that occur once. However, we don't know exactly when. We only know they occurred during the reporting period. These include things like crashes and hangs. To represent diagnostics, we emit a top-level `Span` called `"MXDiagnosticPayload"` with the start and end corresponding to the reporting period. Then, for each event, we emit an OTel "log" for the event. I used logs instead of traces, because each event is instantaneous as far as we know. Also, I wanted to be consistent with the way the Android OTel auto-instrumentation represents uncaught exceptions. Each log has a name attribute for its type, with the key `"metrickit.diagnostic.name"`. The logs have metadata attached with namespaced keys, similar to metrics. For example, crash exception codes have the key `"metrickit.diagnostic.crash.exception.code"`. Since we don't know the exact times of the events, all logs use the end time of the reporting period. This helps so that data shows up as new data in Honeycomb when it arrives.

## How to verify that this has the expected result

There are copious smoke tests to make sure that all of the expected values are present, and that all values are using the correct units, since that's an easy mistake to make when working with the Measurement class. They probably look like overkill, but already caught several fields I had overlooked during development.

`make smoke`

Apple makes it very difficult to test MetricKit in general. It does not work in the simulator at all. With physical devices in debug mode, there is a menu option to send a simulated payload, but it always sends the same values. And a real app only sends a batch once a day. I have manually tested this with the simulated payload.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207968470870231