### PR TITLE
chore(swift): update for new swift format

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -4,7 +4,7 @@
 
 **Required:**
 
-- Xcode (from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835))
+- Xcode 16.0 or later (from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835))
 
 Development and unit tests are done within Xcode. However, there is also a smoke-test, which must be run using the included Makefile.
 
@@ -26,13 +26,6 @@ To install the Xcode Command Line Tools, first install and run Xcode. Then run:
 
 ```sh
 xcode-select --install
-```
-
-If you are on Xcode 16.0 or later, `swift-format` is pre-installed. But if you are on an earlier
-version, you can install it manually with brew.
-
-```sh
-brew install swift-format
 ```
 
 Install `bats-core` and `jq` for local testing:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 
 lint:
-	swift-format lint --strict --recursive .
+	swift format lint --strict --recursive .
 
 format:
-	swift-format format --in-place --recursive .
+	swift format format --in-place --recursive .
 
 #: cleans up smoke test output
 clean-smoke-tests:


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the Makefile and instructions for running swift format.

## Short description of the changes

As of Xcode 16, released this week, `swift format` is now included automatically with Xcode. This is now the recommended way to run what was previously released as `swift-format` and had to be installed with brew.

While it would be technically possible to write a script to automatically detect `swift-format` vs `swift format`, the complexity would not be worth the hassle, as it's recommended to use the latest version of Xcode anyway.

This has the nice side effect that it should fix our circleci lint checks.

## How to verify that this has the expected result

`make lint`
`make format`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208249202227272