### PR TITLE
fix(swift): update the test scheme for circleci unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           device: "iPhone 15"
       - checkout
       - run: xcodebuild -version
-      - run: xcodebuild test -scheme honeycomb-opentelemetry-swift -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
+      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
 
 workflows:
   lint:


### PR DESCRIPTION
## Which problem is this PR solving?

This fixes circleci unit tests that were broken by PR #7.

## Short description of the changes

When we added the example app, we moved to using a Workspace. I had tested that inside Xcode and with the smoke-tests, but I didn't test the circleci-specific command that runs the unit tests. Once this and the swift lint are green, I will add these circleci checks to the repo as presubmit checks.

## How to verify that this has the expected result

I tested the command locally, but the real test is circleci turning green.