### PR TITLE
refactor(swift): Use BatchSpanProcessor instead of SimpleSpanProcessor

### DIFF
--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -15,7 +15,6 @@ import StdoutExporter
 //
 // * DeterministicSampler.
 // * BaggageSpanProcessor.
-// * BatchSpanProcessor.
 // * LoggingMetricExporter.
 // * Debug logging.
 
@@ -95,7 +94,7 @@ public class Honeycomb {
             } else {
                 traceExporter
             }
-        let spanProcessor = SimpleSpanProcessor(spanExporter: spanExporter)
+        let spanProcessor = BatchSpanProcessor(spanExporter: spanExporter)
 
         let tracerProvider = TracerProviderBuilder()
             .add(spanProcessor: spanProcessor)


### PR DESCRIPTION
## Which problem is this PR solving?
Use `BatchSpanProcessor` instead of `SimpleSpanProcessor` since it is the recommended span processor to use in production apps.

Leaving this in draft to start because this might affect smoke tests since it might take a few seconds for the spans to batch send with this change so we might need to add in a wait mechanism.

## Short description of the changes
- Use `BatchSpanProcessor` from OTel as the default span processor to send spans.

## How to verify that this has the expected result
- Smoke tests still pass 