### PR TITLE
chore(circleci): update config.yml for nightly workflow and build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
-
 version: 2.1
+
+filters_always: &filters_always
+  filters:
+    tags:
+      only: /.*/
 
 orbs:
   macos: circleci/macos@2
@@ -29,7 +33,7 @@ jobs:
       - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
 
 workflows:
-  lint:
+  nightly:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -39,15 +43,11 @@ workflows:
                 - main
     jobs:
       - lint
-
-  unit-tests:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
       - tests
 
+  build:
+    jobs:
+      - lint:
+          <<: *filters_always
+      - tests:
+          <<: *filters_always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,17 +33,17 @@ jobs:
       - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
 
 workflows:
-  # nightly:
-  #   triggers:
-  #     - schedule:
-  #         cron: "0 0 * * *"
-  #         filters:
-  #           branches:
-  #             only:
-  #               - main
-  #   jobs:
-  #     - lint
-  #     - tests
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - lint
+      - tests
 
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,17 +33,17 @@ jobs:
       - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
 
 workflows:
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - lint
-      - tests
+  # nightly:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 0 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main
+  #   jobs:
+  #     - lint
+  #     - tests
 
   build:
     jobs:


### PR DESCRIPTION
## Which problem is this PR solving?
Updates CircleCI to have two workflows:
- `nightly` cron workflow that runs tests and lint
-  `build` workflow that runs on every PR and on main, runs tests and lint

## Short description of the changes
- Updated CircleCI config to have multiple workflows
- Updated GitHub repo to require `build` to pass to allow merging on a PR

