### PR TITLE
ci: Run smoke tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,17 +54,15 @@ jobs:
             bats --version
       - run: xcodebuild -version
       - run:
-          name: Install Docker Compose
-          environment:
-            COMPOSE_VERSION: "v2.25.0"
+          name: Install OTel Collector
+          # environment:
+          #   COMPOSE_VERSION: "v2.25.0"
           command: |
-            curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
-            mkdir -p ~/.docker/cli-plugins
-            chmod +x ~/docker-compose
-            mv ~/docker-compose ~/.docker/cli-plugins/docker-compose
+            curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.111.0/otelcol_0.111.0_darwin_arm64.tar.gz
+            tar -xvf otelcol_0.111.0_darwin_arm64.tar.gz
       - run:
-          name: Build and run the collector
-          command: docker compose up --build collector --detach
+          name: Start OTel Collector
+          command: ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml
 workflows:
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ workflows:
     jobs:
       - lint
       - tests
+      - smoke_tests
 
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,8 @@ jobs:
             chmod +x ~/docker-compose
             mv ~/docker-compose ~/.docker/cli-plugins/docker-compose
       - run:
-          name: Spin up and run e2e smoke tests
-          command: make smoke
+          name: Build and run the collector
+          command: docker compose up --build collector --detach
 workflows:
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,10 @@ jobs:
           background: true
       - run:
           name: Run iOS App
-          command: bash ./run-ios-tests.sh
+          command: make ios-tests
       - run:
           name: Run Smoke Tests
-          command: cd smoke-tests && bats ./smoke-e2e.bats --report-formatter junit --output ./
+          command: make smoke-bats
 workflows:
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,11 @@ jobs:
       - run: xcodebuild -version
       - run:
           name: Install OTel Collector
-          # environment:
-          #   COMPOSE_VERSION: "v2.25.0"
+          environment:
+            COLLECTOR_VERSION: "0.111.0"
           command: |
-            curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.111.0/otelcol_0.111.0_darwin_arm64.tar.gz
-            tar -xvf otelcol_0.111.0_darwin_arm64.tar.gz
+            curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${COLLECTOR_VERSION}/otelcol_${COLLECTOR_VERSION}_darwin_arm64.tar.gz
+            tar -xvf otelcol_${COLLECTOR_VERSION}_darwin_arm64.tar.gz
       - run:
           name: Start OTel Collector
           command: touch ./smoke-tests/collector/data.json && ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             tar -xvf otelcol_0.111.0_darwin_arm64.tar.gz
       - run:
           name: Start OTel Collector
-          command: ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml
+          command: touch ./smoke-tests/collector/data.json && ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml
 workflows:
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           background: true
       - run:
           name: Run iOS App
-          command: ./run-ios-tests.sh
+          command: bash ./run-ios-tests.sh
       - run:
           name: Run Smoke Tests
           command: cd smoke-tests && bats ./smoke-e2e.bats --report-formatter junit --output ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             tar -xvf otelcol_${COLLECTOR_VERSION}_darwin_arm64.tar.gz
       - run:
           name: Start OTel Collector
-          command: touch ./smoke-tests/collector/data.json && ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml
+          command: touch ./smoke-tests/collector/data.json && ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml --set="exporters::file::path=./smoke-tests/collector/data.json"
           background: true
       - run:
           name: Run iOS App

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ filters_always: &filters_always
 
 orbs:
   macos: circleci/macos@2
+  bats: circleci/bats@1.0.0
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,12 @@ jobs:
           name: Start OTel Collector
           command: touch ./smoke-tests/collector/data.json && ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml
           background: true
+      - run:
+          name: Run iOS App
+          command: ./run-ios-tests.sh
+      - run:
+          name: Run Smoke Tests
+          command: cd smoke-tests && bats ./smoke-e2e.bats --report-formatter junit --output ./
 workflows:
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,20 @@ jobs:
       - run: xcodebuild -version
       - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
 
+  smoke_tests:
+    macos:
+      xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
+
+    steps:
+      - macos/preboot-simulator:
+          version: "17.5"
+          platform: "iOS"
+          device: "iPhone 15"
+      - checkout
+      - run: xcodebuild -version
+      - run: xcodebuild test -scheme SmokeTest -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
+
 workflows:
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,15 @@ jobs:
             bats --version
       - run: xcodebuild -version
       - run:
+          name: Install Docker Compose
+          environment:
+            COMPOSE_VERSION: "v2.25.0"
+          command: |
+            curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+            mkdir -p ~/.docker/cli-plugins
+            chmod +x ~/docker-compose
+            mv ~/docker-compose ~/.docker/cli-plugins/docker-compose
+      - run:
           name: Spin up and run e2e smoke tests
           command: make smoke
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,3 +65,5 @@ workflows:
           <<: *filters_always
       - tests:
           <<: *filters_always
+      - smoke_tests:
+          <<: *filters_always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,23 @@ jobs:
     resource_class: macos.m1.medium.gen1
 
     steps:
+      - attach_workspace:
+          at: ./
       - macos/preboot-simulator:
           version: "17.5"
           platform: "iOS"
           device: "iPhone 15"
       - checkout
+      - bats/install
+      - run:
+          name: What's the BATS?
+          command: |
+            which bats
+            bats --version
       - run: xcodebuild -version
-      - run: xcodebuild test -scheme SmokeTest -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
-
+      - run:
+          name: Spin up and run e2e smoke tests
+          command: make smoke
 workflows:
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
       - run:
           name: Start OTel Collector
           command: touch ./smoke-tests/collector/data.json && ./otelcol --config=./smoke-tests/collector/otel-collector-config.yaml
+          background: true
 workflows:
   nightly:
     triggers:

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -9,7 +9,7 @@ processors:
 
 exporters:
   file:
-    path: ./smoke-tests/collector/data.json
+    path: /var/lib/data.json
   debug:
     verbosity: detailed
 

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -21,8 +21,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [file, logging]
+      exporters: [file, debug]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [file, logging]
+      exporters: [file, debug]

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -9,7 +9,7 @@ processors:
 
 exporters:
   file:
-    path: /var/lib/data.json
+    path: ./smoke-test/collector/data.json
   debug:
     verbosity: detailed
 

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -9,7 +9,7 @@ processors:
 
 exporters:
   file:
-    path: ./smoke-test/collector/data.json
+    path: ./smoke-tests/collector/data.json
   debug:
     verbosity: detailed
 

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -10,7 +10,7 @@ processors:
 exporters:
   file:
     path: /var/lib/data.json
-  logging:
+  debug:
     verbosity: detailed
 
 service:


### PR DESCRIPTION
## Which problem is this PR solving?
Run smoke tests in CI on every branch/PR and nightly on main.

## Short description of the changes
- Add smoke_tests job to Circle CI
- Install the collector directly on the CI machine instead of through docker to run smoke tests against

## How to verify that this has the expected result
- [Smoke tests run and pass on CI](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-swift/125/workflows/1041f6bd-8e50-4b47-9e04-84b3c2c09dea/jobs/169)
- Smoke tests still run and pass locally


![Screenshot 2024-10-10 at 3 39 16 PM](https://github.com/user-attachments/assets/8d7b699b-08c3-421d-be5b-690029b54785)
