### PR TITLE
feat(debug): Add configuration debug statements

### DIFF
--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -39,6 +39,11 @@ public class Honeycomb {
     static private let metricKitSubscriber = MetricKitSubscriber()
 
     static public func configure(options: HoneycombOptions) throws {
+
+        if options.debug {
+            configureDebug(options: options)
+        }
+
         guard let tracesEndpoint = URL(string: options.tracesEndpoint) else {
             throw HoneycombOptionsError.malformedURL(options.tracesEndpoint)
         }
@@ -167,10 +172,6 @@ public class Honeycomb {
 
         if #available(iOS 13.0, macOS 12.0, *) {
             MXMetricManager.shared.add(self.metricKitSubscriber)
-        }
-
-        if options.debug {
-            debugOptions(options: options)
         }
     }
 }

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -168,5 +168,9 @@ public class Honeycomb {
         if #available(iOS 13.0, macOS 12.0, *) {
             MXMetricManager.shared.add(self.metricKitSubscriber)
         }
+
+        if options.debug {
+            debugOptions(options: options)
+        }
     }
 }

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -3,7 +3,7 @@ import Foundation
 internal func configureDebug(options: HoneycombOptions) {
 
     if options.debug {
-        print("🐝 Honeycomb SDK Debug Mode Enabled🐝 ")
+        print("🐝 Honeycomb SDK Debug Mode Enabled🐝")
 
         print("API Key configured for traces: \(options.tracesApiKey)")
         print("Service Name configured for traces: \(options.serviceName)")

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -1,0 +1,30 @@
+import os;
+
+public func debugOptions(options: HoneycombOptions) {
+
+    if !options.debug {
+        return;
+    }
+    
+    if #available(OSX 11.0, *) {
+        let sdkLog = Logger(subsystem: "io.honeycomb", category: "SDK");
+
+        sdkLog.debug("Honeycomb SDK Debug Mode Enabled")
+
+        sdkLog.debug("API Key configured for traces: \(options.tracesApiKey)")
+        sdkLog.debug("Service Name configured for traces: \(options.serviceName)")
+        sdkLog.debug("Endpoint configured for traces: \(options.tracesEndpoint)")
+        sdkLog.debug("Sample Rate configured for traces: \(options.sampleRate)")
+    } else {
+        let sdkLog = OSLog(subsystem: "io.honeycomb", category: "SDK")
+
+        os_log("Honeycomb SDK Debug Mode Enabled", log: sdkLog, type: .debug)
+
+        // API Key
+        os_log("API Key configured for traces: %@", log: sdkLog, type: .debug, options.tracesApiKey)
+        os_log("Service Name configured for traces: %@", log: sdkLog, type: .debug, options.serviceName)
+        os_log("Endpoint configured for traces: %@", log: sdkLog, type: .debug, options.tracesEndpoint)
+        os_log("Sample Rate configured for traces: %@", log: sdkLog, type: .debug, options.sampleRate)
+    }
+
+}

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -1,4 +1,4 @@
-import Foundation;
+import Foundation
 
 internal func debugOptions(options: HoneycombOptions) {
     

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 internal func debugOptions(options: HoneycombOptions) {
-    
 
     if options.debug {
         print("Honeycomb SDK Debug Mode Enabled")

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -3,7 +3,7 @@ import Foundation
 internal func debugOptions(options: HoneycombOptions) {
 
     if options.debug {
-        print("Honeycomb SDK Debug Mode Enabled")
+        print("🐝 Honeycomb SDK Debug Mode Enabled🐝 ")
 
         print("API Key configured for traces: \(options.tracesApiKey)")
         print("Service Name configured for traces: \(options.serviceName)")

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -1,6 +1,6 @@
 import os;
 
-public func debugOptions(options: HoneycombOptions) {
+internal func debugOptions(options: HoneycombOptions) {
 
     if !options.debug {
         return;

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -1,30 +1,14 @@
-import os;
+import Foundation;
 
 internal func debugOptions(options: HoneycombOptions) {
-
-    if !options.debug {
-        return;
-    }
     
-    if #available(OSX 11.0, *) {
-        let sdkLog = Logger(subsystem: "io.honeycomb", category: "SDK");
 
-        sdkLog.debug("Honeycomb SDK Debug Mode Enabled")
+    if options.debug {
+        print("Honeycomb SDK Debug Mode Enabled")
 
-        sdkLog.debug("API Key configured for traces: \(options.tracesApiKey)")
-        sdkLog.debug("Service Name configured for traces: \(options.serviceName)")
-        sdkLog.debug("Endpoint configured for traces: \(options.tracesEndpoint)")
-        sdkLog.debug("Sample Rate configured for traces: \(options.sampleRate)")
-    } else {
-        let sdkLog = OSLog(subsystem: "io.honeycomb", category: "SDK")
-
-        os_log("Honeycomb SDK Debug Mode Enabled", log: sdkLog, type: .debug)
-
-        // API Key
-        os_log("API Key configured for traces: %@", log: sdkLog, type: .debug, options.tracesApiKey)
-        os_log("Service Name configured for traces: %@", log: sdkLog, type: .debug, options.serviceName)
-        os_log("Endpoint configured for traces: %@", log: sdkLog, type: .debug, options.tracesEndpoint)
-        os_log("Sample Rate configured for traces: %@", log: sdkLog, type: .debug, options.sampleRate)
+        print("API Key configured for traces: \(options.tracesApiKey)")
+        print("Service Name configured for traces: \(options.serviceName)")
+        print("Endpoint configured for traces: \(options.tracesEndpoint)")
+        print("Sample Rate configured for traces: \(options.sampleRate)")
     }
-
 }

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal func debugOptions(options: HoneycombOptions) {
+internal func configureDebug(options: HoneycombOptions) {
 
     if options.debug {
         print("🐝 Honeycomb SDK Debug Mode Enabled🐝 ")


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

setting `debug: true` in the config currently does nothing

## Short description of the changes

Adds debug statements to the SDK, print out basic debugging information on SDK init.

## How to verify that this has the expected result
1. set debug to true and run the smoke test/example
2. debug information should print out in the console.
