### PR TITLE
feat: add UIKit touch auto-instrumentation

### DIFF
--- a/Examples/SmokeTest/SmokeTest/UIKitView.storyboard
+++ b/Examples/SmokeTest/SmokeTest/UIKitView.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,13 +16,43 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" fixedFrame="YES" image="globe" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="O94-9o-FQ4">
-                                <rect key="frame" x="169" y="216" width="54" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="globe" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="O94-9o-FQ4">
+                                <rect key="frame" x="171.66666666666666" y="376.66666666666669" width="50" height="48.666666666666686"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="Fba-48-zi9"/>
+                                    <constraint firstAttribute="width" constant="50" id="GvM-3x-MxK"/>
+                                </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Sample UIKit App" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="008-k5-M1T">
-                                <rect key="frame" x="130" y="266" width="133" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sample UIKit App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="008-k5-M1T">
+                                <rect key="frame" x="130" y="442" width="133" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Boa-QF-90l">
+                                <rect key="frame" x="16" y="767" width="361" height="35"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Simple Button"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zfX-ff-qIS">
+                                <rect key="frame" x="16" y="716" width="361" height="35"/>
+                                <accessibility key="accessibilityConfiguration" identifier="accessibleButton"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Accessible Button"/>
+                            </button>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="DzX-1X-ZOc">
+                                <rect key="frame" x="16" y="669" width="361" height="32"/>
+                                <segments>
+                                    <segment title="Segmented"/>
+                                    <segment title="Button"/>
+                                </segments>
+                            </segmentedControl>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Switch" translatesAutoresizingMaskIntoConstraints="NO" id="ks9-AV-zp6">
+                                <rect key="frame" x="328" y="622" width="51" height="31"/>
+                                <accessibility key="accessibilityConfiguration" identifier="switch"/>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Switch" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n89-o3-f07">
+                                <rect key="frame" x="16.000000000000004" y="627" width="51.333333333333343" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -30,6 +60,25 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="ks9-AV-zp6" secondAttribute="trailing" constant="16" id="34M-ZV-0ya"/>
+                            <constraint firstItem="zfX-ff-qIS" firstAttribute="top" secondItem="DzX-1X-ZOc" secondAttribute="bottom" constant="16" id="3eY-tS-YQ1"/>
+                            <constraint firstItem="O94-9o-FQ4" firstAttribute="bottom" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" id="7U7-eW-BRK"/>
+                            <constraint firstItem="zfX-ff-qIS" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="Cmr-4G-4aM"/>
+                            <constraint firstItem="Boa-QF-90l" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="IPb-0s-21g"/>
+                            <constraint firstItem="ks9-AV-zp6" firstAttribute="centerY" secondItem="n89-o3-f07" secondAttribute="centerY" id="KYa-HI-CEa"/>
+                            <constraint firstItem="008-k5-M1T" firstAttribute="top" secondItem="O94-9o-FQ4" secondAttribute="bottom" constant="16" id="Sg3-Ec-qwk"/>
+                            <constraint firstItem="n89-o3-f07" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="YGK-Ax-o2a"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="DzX-1X-ZOc" secondAttribute="trailing" constant="16" id="ewi-3P-0AT"/>
+                            <constraint firstItem="DzX-1X-ZOc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="fXA-Y5-41O"/>
+                            <constraint firstItem="Boa-QF-90l" firstAttribute="top" secondItem="zfX-ff-qIS" secondAttribute="bottom" constant="16" id="gng-cj-6eK"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Boa-QF-90l" secondAttribute="bottom" constant="16" id="iqq-HI-v26"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="zfX-ff-qIS" secondAttribute="trailing" constant="16" id="jcQ-5o-UTD"/>
+                            <constraint firstItem="O94-9o-FQ4" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="qtd-4m-nze"/>
+                            <constraint firstItem="DzX-1X-ZOc" firstAttribute="top" secondItem="ks9-AV-zp6" secondAttribute="bottom" constant="16" id="uoj-ry-roG"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Boa-QF-90l" secondAttribute="trailing" constant="16" id="up8-ZX-dl7"/>
+                            <constraint firstItem="008-k5-M1T" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="xun-d3-rYB"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Examples/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
+++ b/Examples/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
@@ -153,12 +153,28 @@ final class SmokeTestUITests: XCTestCase {
         app.buttons["Flush"].tap()
     }
 
-    func testUIKitInstrimentation() throws {
+    func testUIKitNavigationInstrumentation() throws {
         let app = XCUIApplication()
         app.launch()
         app.buttons["UIKit"].tap()
         XCTAssert(app.staticTexts["Sample UIKit App"].waitForExistence(timeout: uiUpdateTimeout))
 
+        app.buttons["Core"].tap()
+        XCTAssert(app.buttons["Flush"].waitForExistence(timeout: uiUpdateTimeout))
+        app.buttons["Flush"].tap()
+    }
+    
+    func testUIKitInteractionInstrumentation() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.buttons["UIKit"].tap()
+        XCTAssert(app.staticTexts["Sample UIKit App"].waitForExistence(timeout: uiUpdateTimeout))
+
+        app.buttons["Simple Button"].tap()
+        app.buttons["Accessible Button"].tap()
+        app.switches.firstMatch.tap()
+        app.buttons["Segmented"].tap()
+        
         app.buttons["Core"].tap()
         XCTAssert(app.buttons["Flush"].waitForExistence(timeout: uiUpdateTimeout))
         app.buttons["Flush"].tap()

--- a/Examples/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
+++ b/Examples/SmokeTest/SmokeTestUITests/SmokeTestUITests.swift
@@ -163,7 +163,7 @@ final class SmokeTestUITests: XCTestCase {
         XCTAssert(app.buttons["Flush"].waitForExistence(timeout: uiUpdateTimeout))
         app.buttons["Flush"].tap()
     }
-    
+
     func testUIKitInteractionInstrumentation() throws {
         let app = XCUIApplication()
         app.launch()
@@ -174,7 +174,7 @@ final class SmokeTestUITests: XCTestCase {
         app.buttons["Accessible Button"].tap()
         app.switches.firstMatch.tap()
         app.buttons["Segmented"].tap()
-        
+
         app.buttons["Core"].tap()
         XCTAssert(app.buttons["Flush"].waitForExistence(timeout: uiUpdateTimeout))
         app.buttons["Flush"].tap()

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Specifically, it will emit 2 kinds of span for each view that is wrapped:
 
 `View Render` spans encompass the entire rendering process, from initialization to appearing on screen. They include the following attributes:
 - `view.name` (string): the name passed to `HoneycombInstrumentedView`
-- `view.enderDuration` (double): amount of time to spent initializing the contents of `HoneycombInstrumentedView`
-- `view.otalDuration` (double): amount of time from when `HoneycombInstrumentedView.body()` is called to when the contents appear on screen
+- `view.renderDuration` (double): amount of time to spent initializing the contents of `HoneycombInstrumentedView`
+- `view.totalDuration` (double): amount of time from when `HoneycombInstrumentedView.body()` is called to when the contents appear on screen
 
 `View Body` spans encompass just the `body()` call of `HoneycombInstrumentedView, and include the following attributes:
 - `view.name` (string): the name passed to `HoneycombInstrumentedView` 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ The following auto-instrumentation libraries are automatically included:
 
 UIKit views will automatically be instrumented, emitting `viewDidAppear` and `viewDidDisappear` events. Both have the following attributes:
 
-- `title` - Title of the view, if provided.
-- `nibName` - The name of the view controller's nib file, if one was specified.
-- `animated` - true if the transition to/from this view is animated, false if it isn't.
-- `className` - name of the swift/objective-c class this view 
+- `view.title` - Title of the view controller, if provided.
+- `view.nibName` - The name of the view controller's nib file, if one was specified.
+- `view.animated` - true if the transition to/from this view is animated, false if it isn't.
+- `view.class` - name of the swift/objective-c class this view 
 controller has.
 
 #### Interaction
@@ -126,9 +126,9 @@ This will measure and emit instrumentation for your View's render times, ex:
 Specifically, it will emit 2 kinds of span for each view that is wrapped:
 
 `View Render` spans encompass the entire rendering process, from initialization to appearing on screen. They include the following attributes:
-- `ViewName` (string): the name passed to `HoneycombInstrumentedView`
-- `RenderDuration` (double): amount of time to spent initializing the contents of `HoneycombInstrumentedView`
-- `TotalDuration` (double): amount of time from when `HoneycombInstrumentedView.body()` is called to when the contents appear on screen
+- `view.name` (string): the name passed to `HoneycombInstrumentedView`
+- `view.enderDuration` (double): amount of time to spent initializing the contents of `HoneycombInstrumentedView`
+- `view.otalDuration` (double): amount of time from when `HoneycombInstrumentedView.body()` is called to when the contents appear on screen
 
 `View Body` spans encompass just the `body()` call of `HoneycombInstrumentedView, and include the following attributes:
-- `ViewName` (string): the name passed to `HoneycombInstrumentedView` 
+- `view.name` (string): the name passed to `HoneycombInstrumentedView` 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ To manually send a span:
 
 The following auto-instrumentation libraries are automatically included:
 * [MetricKit](https://developer.apple.com/documentation/metrickit) data is automatically collected.
+* Some UIKit controls are automatically instrumented as described below.
 
 ### UIKit Instrumentation
+
+#### Navigation
 
 UIKit views will automatically be instrumented, emitting `viewDidAppear` and `viewDidDisappear` events. Both have the following attributes:
 
@@ -85,6 +88,21 @@ UIKit views will automatically be instrumented, emitting `viewDidAppear` and `vi
 - `animated` - true if the transition to/from this view is animated, false if it isn't.
 - `className` - name of the swift/objective-c class this view 
 controller has.
+
+#### Interaction
+
+Various touch events are instrumented, such as:
+* `Touch Began` - A touch started
+* `Touch Ended` - A touch ended
+* `click` - A "click". This is currently ony instrumented for `UIButton`s.
+
+These events may have the following attributes. In the case of name attributes, we may walk up the view hierarchy to find a valid entry.
+* `view.class`: e.g. `"UIButton"`
+* `view.accessibilityIdentifier`, The `accessibilityIdentifier` property of a `UIView`, e.g. `"accessibleButton"`
+* `view.accessibilityLabel` - The `accessibilityLabel` property of a `UIView`, e.g. `"Accessible Button"`
+* `view.currentTitle` - The `currentTitle` property of a `UIButton`.
+* `view.titleLabel.text` - The `text` of a `UIButton`'s `titleLabel`, e.g. `"Accessible Button"`
+* `view.name`: The "best" available name of the view, given the other identifiers, e.g. `"accessibleButton"`
 
 ## Manual Instrumentation
 ### SwiftUI View Instrumentation

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -175,6 +175,7 @@ public class Honeycomb {
 
         installNetworkInstrumentation(options: options)
         installUINavigationInstrumentation()
+        installWindowInstrumentation()
 
         if #available(iOS 13.0, macOS 12.0, *) {
             MXMetricManager.shared.add(self.metricKitSubscriber)

--- a/Sources/Honeycomb/HoneycombInstrumentedView.swift
+++ b/Sources/Honeycomb/HoneycombInstrumentedView.swift
@@ -16,7 +16,7 @@ struct HoneycombInstrumentedView<Content: View>: View {
 
         self.span = getViewTracer().spanBuilder(spanName: "View Render")
             .setStartTime(time: Date())
-            .setAttribute(key: "ViewName", value: name)
+            .setAttribute(key: "view.name", value: name)
             .startSpan()
     }
 
@@ -26,7 +26,7 @@ struct HoneycombInstrumentedView<Content: View>: View {
         // contents start init
         let bodySpan = getViewTracer().spanBuilder(spanName: "View Body")
             .setStartTime(time: Date())
-            .setAttribute(key: "ViewName", value: name)
+            .setAttribute(key: "view.name", value: name)
             .setParent(span)
             .setActive(true)
             .startSpan()
@@ -40,7 +40,7 @@ struct HoneycombInstrumentedView<Content: View>: View {
         let endTime = Date()
 
         span.setAttribute(
-            key: "RenderDuration",
+            key: "view.renderDuration",
             value: endTime.timeIntervalSince(start)
         )
 
@@ -53,7 +53,10 @@ struct HoneycombInstrumentedView<Content: View>: View {
             bodySpan.end(time: endTime)
 
             let appearTime = Date()
-            span.setAttribute(key: "TotalDuration", value: appearTime.timeIntervalSince(initTime))
+            span.setAttribute(
+                key: "view.totalDuration",
+                value: appearTime.timeIntervalSince(initTime)
+            )
             span.end(time: appearTime)
         }
     }

--- a/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
@@ -3,7 +3,7 @@
     import OpenTelemetryApi
     import UIKit
 
-    private let honeycombUIKitInstrumentationName = "@honeycombio/instrumentation-uikit"
+    internal let honeycombUIKitInstrumentationName = "@honeycombio/instrumentation-uikit"
 
     internal func getUIKitViewTracer() -> Tracer {
         return OpenTelemetry.instance.tracerProvider.get(

--- a/Sources/Honeycomb/UIKit/UIViewController.swift
+++ b/Sources/Honeycomb/UIKit/UIViewController.swift
@@ -4,21 +4,24 @@
     import UIKit
 
     extension UIViewController {
+        private func setAttributes(span: Span, className: String, animated: Bool) {
+            if let title = self.title {
+                span.setAttribute(key: "view.title", value: title)
+            }
+            if let nibName = self.nibName {
+                span.setAttribute(key: "view.nibName", value: nibName)
+            }
+            span.setAttribute(key: "view.animated", value: animated)
+            span.setAttribute(key: "view.class", value: className)
+        }
+
         @objc func traceViewDidAppear(_ animated: Bool) {
             let className = NSStringFromClass(type(of: self))
 
             // Internal classes from SwiftUI will likely begin with an underscore
             if !className.hasPrefix("_") {
                 let span = getUIKitViewTracer().spanBuilder(spanName: "viewDidAppear").startSpan()
-                if self.title != nil {
-                    span.setAttribute(key: "title", value: self.title!)
-                }
-                if self.nibName != nil {
-                    span.setAttribute(key: "nibName", value: self.nibName!)
-                }
-                span.setAttribute(key: "animated", value: animated)
-                span.setAttribute(key: "className", value: className)
-
+                setAttributes(span: span, className: className, animated: animated)
                 span.end()
             }
 
@@ -33,14 +36,7 @@
             if !className.hasPrefix("_") {
                 let span = getUIKitViewTracer().spanBuilder(spanName: "viewDidDisappear")
                     .startSpan()
-                if self.title != nil {
-                    span.setAttribute(key: "title", value: self.title!)
-                }
-                if self.nibName != nil {
-                    span.setAttribute(key: "nibName", value: self.nibName!)
-                }
-                span.setAttribute(key: "animated", value: animated)
-                span.setAttribute(key: "className", value: className)
+                setAttributes(span: span, className: className, animated: animated)
                 span.end()
             }
 

--- a/Sources/Honeycomb/UIKit/ViewAttributes.swift
+++ b/Sources/Honeycomb/UIKit/ViewAttributes.swift
@@ -1,0 +1,69 @@
+import Foundation
+import OpenTelemetryApi
+import SwiftUI
+import UIKit
+
+struct ViewAttributes {
+    var accessibilityLabel: String?
+    var accessibilityIdentifier: String?
+    var currentTitle: String?
+    var titleLabelText: String?
+    var className: String?
+
+    var name: String? {
+        return accessibilityIdentifier ?? accessibilityLabel ?? currentTitle ?? titleLabelText
+    }
+
+    init(view: UIView) {
+        findNames(view: view)
+    }
+
+    private mutating func findNames(view: UIView) {
+        // Gather various identifiers about the view.
+        if let identifier = view.accessibilityIdentifier {
+            self.accessibilityIdentifier = identifier
+        }
+        if let label = view.accessibilityLabel {
+            self.accessibilityLabel = label
+        }
+        if let button = view as? UIButton {
+            if let title = button.currentTitle {
+                self.currentTitle = title
+            }
+            if let label = button.titleLabel?.text {
+                self.titleLabelText = label
+            }
+        }
+
+        // If we've gotten _some_ identifier, stop. Otherwise, walk up the hierarchy.
+        if self.name == nil {
+            if let parent = view.superview {
+                self.findNames(view: parent)
+            }
+        }
+
+        // Set the class name for the bottom-most view.
+        self.className = String(describing: type(of: view))
+    }
+
+    func setAttributes(span: Span) {
+        if let accessibilityLabel = self.accessibilityLabel {
+            span.setAttribute(key: "view.accessibilityLabel", value: accessibilityLabel)
+        }
+        if let accessibilityIdentifier = self.accessibilityIdentifier {
+            span.setAttribute(key: "view.accessibilityIdentifier", value: accessibilityIdentifier)
+        }
+        if let currentTitle = self.currentTitle {
+            span.setAttribute(key: "view.currentTitle", value: currentTitle)
+        }
+        if let titleLabelText = self.titleLabelText {
+            span.setAttribute(key: "view.titleLabel.text", value: titleLabelText)
+        }
+        if let name = self.name {
+            span.setAttribute(key: "view.name", value: name)
+        }
+        if let className = self.className {
+            span.setAttribute(key: "view.class", value: className)
+        }
+    }
+}

--- a/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
@@ -64,7 +64,6 @@ extension UIWindow {
     @objc func _instrumented_sendEvent(_ event: UIEvent) {
         switch event.type {
         case .touches:
-            //if let touches = event.touches(for: self) {
             if let touches = event.allTouches {
                 for touch in touches {
                     recordTouch(touch)

--- a/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
@@ -60,6 +60,7 @@ private func recordTouch(_ touch: UITouch) {
 }
 
 extension UIWindow {
+    // swift-format-ignore
     @objc func _instrumented_sendEvent(_ event: UIEvent) {
         switch event.type {
         case .touches:

--- a/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
@@ -1,0 +1,154 @@
+
+import Foundation
+import OpenTelemetryApi
+import SwiftUI
+import UIKit
+
+struct ViewNames {
+    var accessibilityLabel: String?
+    var accessibilityIdentifier: String?
+    var currentTitle: String?
+    var titleLabelText: String?
+    var className: String?
+    
+    var name: String? {
+        return accessibilityIdentifier ??
+            accessibilityLabel ??
+            currentTitle ??
+            titleLabelText
+    }
+    
+    init(view: UIView) {
+        findNames(view: view)
+    }
+    
+    private mutating func findNames(view: UIView) {
+        // Gather various identifiers about the view.
+        if let identifier = view.accessibilityIdentifier {
+            self.accessibilityIdentifier = identifier
+        }
+        if let label = view.accessibilityLabel {
+            self.accessibilityLabel = label
+        }
+        if let button = view as? UIButton {
+            if let title = button.currentTitle {
+                self.currentTitle = title
+            }
+            if let label = button.titleLabel?.text {
+                self.titleLabelText = label
+            }
+        }
+
+        // If we've gotten _some_ identifier, stop. Otherwise, walk up the hierarchy.
+        if self.name == nil {
+            if let parent = view.superview {
+                self.findNames(view: parent)
+            }
+        }
+        
+        // Set the class name for the bottom-most view.
+        self.className = String(describing: type(of: view))
+    }
+    
+    func setAttributes(span: Span) {
+        if let accessibilityLabel = self.accessibilityLabel {
+            span.setAttribute(key: "view.accessibilityLabel", value: accessibilityLabel)
+        }
+        if let accessibilityIdentifier = self.accessibilityIdentifier {
+            span.setAttribute(key: "view.accessibilityIdentifier", value: accessibilityIdentifier)
+        }
+        if let currentTitle = self.currentTitle {
+            span.setAttribute(key: "view.currentTitle", value: currentTitle)
+        }
+        if let titleLabelText = self.titleLabelText {
+            span.setAttribute(key: "view.titleLabel.text", value: titleLabelText)
+        }
+        if let name = self.name {
+            span.setAttribute(key: "view.name", value: name)
+        }
+        if let className = self.className {
+            span.setAttribute(key: "view.class", value: className)
+        }
+    }
+}
+
+enum TouchType {
+    case began
+    case ended
+    case cancelled
+}
+
+private func recordTouch(_ touch: UITouch, type: TouchType) {
+    let spanName = switch type {
+    case .began: "Touch Began"
+    case .ended: "Touch Ended"
+    case .cancelled: "Touch Cancelled"
+    }
+
+    // Try to find the name of the view this touch was on.
+    let viewNames: ViewNames? = touch.view.map({ view in ViewNames(view: view) })
+
+    let tracer = OpenTelemetry.instance.tracerProvider.get(
+        instrumentationName: honeycombUIKitInstrumentationName,
+        instrumentationVersion: honeycombLibraryVersion
+    )
+    let span = tracer.spanBuilder(spanName: spanName).startSpan()
+    viewNames?.setAttributes(span: span)
+    span.end()
+    
+    // Do a special check for button clicks.
+    if type == .ended {
+        if let button = touch.view as? UIButton {
+            if button.isHighlighted {
+                let span = tracer.spanBuilder(spanName: "click")
+                    .startSpan()
+                viewNames?.setAttributes(span: span)
+                span.end()
+            }
+        }
+    }
+}
+
+private func recordTouch(_ touch: UITouch) {
+    guard let type: TouchType = switch touch.phase {
+        case .began: TouchType.began
+        case .cancelled: TouchType.cancelled
+        case .ended: TouchType.ended
+        default: nil
+    } else {
+        return
+    }
+    
+    recordTouch(touch, type: type)
+}
+
+extension UIWindow {
+    @objc func _instrumented_sendEvent(_ event: UIEvent) {
+        switch event.type {
+        case .touches:
+            //if let touches = event.touches(for: self) {
+            if let touches = event.allTouches {
+                for touch in touches {
+                    recordTouch(touch)
+                }
+            }
+        default:
+            break;
+        }
+        
+        // Because the methods were swapped, this calls the original method.
+        _instrumented_sendEvent(event)
+    }
+    
+    static func swizzle() {
+        let sendEventSelector = #selector(UIWindow.sendEvent)
+        let instrumentedSendEventSelector = #selector(UIWindow._instrumented_sendEvent)
+        let sendEventMethod = class_getInstanceMethod(self, sendEventSelector)
+        let instrumentedSendEventMethod = class_getInstanceMethod(self, instrumentedSendEventSelector)
+        method_exchangeImplementations(sendEventMethod!, instrumentedSendEventMethod!)
+    }
+}
+
+func installWindowInstrumentation() {
+    UIWindow.swizzle()
+}

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -173,7 +173,7 @@ mk_diag_attr() {
    7 "View Render"'
    
   # the View Render spans are tracking the views we expect
-  total_duration=$(attribute_for_span_key "@honeycombio/instrumentation-view" "View Render" ViewName string | sort)
+  total_duration=$(attribute_for_span_key "@honeycombio/instrumentation-view" "View Render" "view.name" string | sort)
   assert_equal "$total_duration" '"expensive text 1"
 "expensive text 2"
 "expensive text 3"
@@ -185,13 +185,13 @@ mk_diag_attr() {
 
 @test "UIViewController attributes are correct" {
     result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
-        | jq "select (.key == \"className\")" \
+        | jq "select (.key == \"view.class\")" \
         | jq "select (.value.stringValue == \"UIViewController\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UIViewController"'
 
     result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidDisappear \
-        | jq "select (.key == \"className\")" \
+        | jq "select (.key == \"view.class\")" \
         | jq "select (.value.stringValue == \"UIViewController\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UIViewController"'
@@ -199,7 +199,7 @@ mk_diag_attr() {
 
 @test "UITabView attributes are correct" {
     result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
-        | jq "select (.key == \"className\")" \
+        | jq "select (.key == \"view.class\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"SwiftUI.UIKitTabBarController"'

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -181,24 +181,60 @@ mk_diag_attr() {
 "main view"
 "nested expensive text"
 "nested expensive view"'
-
 }
 
 @test "UIViewController attributes are correct" {
-    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear | \
-         jq "select (.key == \"className\")" | \
-         jq "select (.value.stringValue == \"UIViewController\").value.stringValue")
+    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
+        | jq "select (.key == \"className\")" \
+        | jq "select (.value.stringValue == \"UIViewController\").value.stringValue" \
+        | uniq)
     assert_equal "$result" '"UIViewController"'
 
-        result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidDisappear | \
-         jq "select (.key == \"className\")" | \
-         jq "select (.value.stringValue == \"UIViewController\").value.stringValue")
+    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidDisappear \
+        | jq "select (.key == \"className\")" \
+        | jq "select (.value.stringValue == \"UIViewController\").value.stringValue" \
+        | uniq)
     assert_equal "$result" '"UIViewController"'
 }
 
 @test "UITabView attributes are correct" {
-    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear | \
-         jq "select (.key == \"className\")" | \
-         jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController\").value.stringValue" | uniq -c)
-    assert_equal "$result" '   5 "SwiftUI.UIKitTabBarController"'
+    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
+        | jq "select (.key == \"className\")" \
+        | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController\").value.stringValue" \
+        | uniq)
+    assert_equal "$result" '"SwiftUI.UIKitTabBarController"'
+}
+
+@test "UIKit touch events are captured" {
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Began" "Simple Button")
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Began" "accessibleButton")
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Began" "switch")
+
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Ended" "Simple Button")
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Ended" "accessibleButton")
+    # UISwitch does not support Touch Ended events at this time. Apple sets the view to null.
+}
+
+@test "UIKit click events are captured" {
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "click" "Simple Button")
+    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "click" "accessibleButton")
+}
+
+@test "UIKit touch events have all attributes" {
+    span=$(spans_on_view_named "@honeycombio/instrumentation-uikit" "click" "accessibleButton")
+
+    name=$(echo "$span" | jq '.attributes[] | select(.key == "view.name").value.stringValue')
+    assert_equal "$name" '"accessibleButton"'
+
+    class=$(echo "$span" | jq '.attributes[] | select(.key == "view.class").value.stringValue')
+    assert_equal "$class" '"UIButton"'
+
+    label=$(echo "$span" | jq '.attributes[] | select(.key == "view.accessibilityLabel").value.stringValue')
+    assert_equal "$label" '"Accessible Button"'
+
+    identifier=$(echo "$span" | jq '.attributes[] | select(.key == "view.accessibilityIdentifier").value.stringValue')
+    assert_equal "$identifier" '"accessibleButton"'
+
+    text=$(echo "$span" | jq '.attributes[] | select(.key == "view.titleLabel.text").value.stringValue')
+    assert_equal "$text" '"Accessible Button"'
 }

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -1,5 +1,19 @@
 # UTILITY FUNCS
 
+# Spans on a particular view.
+# Arguments:
+#   $1 - scope
+#   $2 - span name
+#   $3 - view.name
+spans_on_view_named() {
+    spans_received | jq ".scopeSpans[] \
+        | select(.scope.name == \"$1\").spans[] \
+        | select (.name == \"$2\") as \$span \
+        | .attributes?[]? \
+        | select (.key? == \"view.name\" and .value.stringValue == \"$3\") \
+		| \$span"
+}
+
 # Span names for a given scope
 # Arguments: $1 - scope name
 span_names_for() {
@@ -98,9 +112,24 @@ assert_equal() {
 
 # Fail and display details if the actual value is empty.
 # Arguments: $1 - actual result
-assert_not_empty() {
+assert_not_empty_string() {
 	EMPTY=(\"\")
 	if [[ "$1" == "${EMPTY}" ]]; then
+		{
+			echo
+			echo "-- 💥 value is empty 💥 --"
+			echo "value : $1"
+			echo "--"
+			echo
+		} >&2 # output error to STDERR
+		return 1
+	fi
+}
+
+# Fail and display details if the actual value is empty.
+# Arguments: $1 - actual result
+assert_not_empty() {
+	if [[ "$1" == "" ]]; then
 		{
 			echo
 			echo "-- 💥 value is empty 💥 --"

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -11,7 +11,7 @@ spans_on_view_named() {
         | select (.name == \"$2\") as \$span \
         | .attributes?[]? \
         | select (.key? == \"view.name\" and .value.stringValue == \"$3\") \
-		| \$span"
+        | \$span"
 }
 
 # Span names for a given scope


### PR DESCRIPTION
## Which problem is this PR solving?

* Adds touch auto-instrumentation for `UIKit`, tracking `"Touch Began"`, `"Touch Ended"`, and for `UIButton`, `"click"`.
* Changes attributes on View auto-instrumentation to be more consistent, using lowercase naming and a `view.` namespace.

This instrumentation may be too verbose, but it's a first pass at having something to play with.

## Short description of the changes

See the README changes for more details.

## How to verify that this has the expected result

Smoke tests and manual verification.