### PR TITLE
fix: fix resource construction to include defaults

### DIFF
--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -68,7 +68,10 @@ public class Honeycomb {
             headers: createKeyValueList(options.logsHeaders)
         )
 
-        let resource = Resource.init(attributes: createAttributeDict(options.resourceAttributes))
+        // The default constructor includes a bunch of automatic values we want,
+        // so it's important to create a default one and then merge our own.
+        let resource = Resource()
+            .merging(other: Resource(attributes: createAttributeDict(options.resourceAttributes)))
 
         // Traces
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -17,6 +17,13 @@ teardown_file() {
   assert_equal "$result" '"test-span"'
 }
 
+@test "SDK had default resources" {
+  result=$(resource_attributes_received \
+      | jq 'select (.key == "telemetry.sdk.language").value.stringValue' \
+      | sort | uniq)
+  assert_equal "$result" '"swift"'
+}
+
 # A helper just for MetricKit attributes, because there's so many of them.
 # Arguments:
 #   $1 - attribute key
@@ -283,8 +290,8 @@ mk_diag_attr() {
 
 @test "Navigation spans are correct" {
     result=$(attribute_for_span_key "@honeycombio/instrumentation-navigation" Navigation "screen.name" string \
-    | sort \
-    | uniq -c)
+        | sort \
+        | uniq -c)
     root_count=$(echo "$result" | grep "\[\]")
     yosemite_count=$(echo "$result" | grep "Yosemite")
     


### PR DESCRIPTION
## Which problem is this PR solving?

Our SDK was not setting `telemetry.sdk.language` and other default resource fields, even though the upstream SDK was.

## Short description of the changes

We need to call the _default_ constructor for the `Resource` object and then merge in our own fields, rather than just passing in our own fields.

## How to verify that this has the expected result

There is a new smoke test.