### PR TITLE
maint: various small fixes to core swift SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 Honeycomb OpenTelemetry SDK Changelog
 
+## v.Next
+
+### New Features
+
+* Update to OpenTelemetry Swift 1.12.1.
+* Auto-instrumentation of URLSession.
+* Auto-instrumentation of navigation in UI Kit.
+* Auto-instrumentation of "clicks" and touch events in UI Kit.
+* Manual instrumentation of SwiftUI navigation.
+* Manual instrumentation of SwiftUI view rendering.
+
 ## 0.0.1-alpha (2024-09-27)
 
 Initial experimental release.

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
         .library(name: "Honeycomb", type: .static, targets: ["Honeycomb"])
     ],
     dependencies: [
-        // This revision is needed for now to avoid unsafe flags.
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "1.10.1")
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "1.12.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,8 @@
 # Releasing
 
-- `Add steps to prepare release`
+- Update `honeycombLibraryVersion` in `Sources/Honeycomb/HoneycombVersion.swift`.
 - Update `CHANGELOG.md` with the changes since the last release.
 - Commit changes, push, and open a release preparation pull request for review.
 - Once the pull request is merged, fetch the updated `main` branch.
 - Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.2.3 -m "v1.2.3"`)
 - Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v1.2.3`
-- Copy change log entry for newest version into draft GitHub release created as part of CI publish steps.
-  - Make sure to "generate release notes" in github for full changelog notes and any new contributors
-- Publish the github draft release and this will kick off publishing to GitHub and the NPM registry.

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -11,14 +11,6 @@ import ResourceExtension
 import StdoutExporter
 import SwiftUI
 
-// TODO: Implement the following features.
-//       https://github.com/honeycombio/specs/blob/main/specs/otel-sdk-distro.md
-//
-// * DeterministicSampler.
-// * BaggageSpanProcessor.
-// * LoggingMetricExporter.
-// * Debug logging.
-
 private func createAttributeDict(_ dict: [String: String]) -> [String: AttributeValue] {
     var result: [String: AttributeValue] = [:]
     for (key, value) in dict {

--- a/Sources/Honeycomb/HoneycombDebug.swift
+++ b/Sources/Honeycomb/HoneycombDebug.swift
@@ -1,13 +1,8 @@
 import Foundation
 
 internal func configureDebug(options: HoneycombOptions) {
-
     if options.debug {
-        print("🐝 Honeycomb SDK Debug Mode Enabled🐝")
-
-        print("API Key configured for traces: \(options.tracesApiKey)")
-        print("Service Name configured for traces: \(options.serviceName)")
-        print("Endpoint configured for traces: \(options.tracesEndpoint)")
-        print("Sample Rate configured for traces: \(options.sampleRate)")
+        print("🐝 Honeycomb SDK Debug Mode Enabled 🐝")
+        print("Honeycomb options: \(options)")
     }
 }

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -1,10 +1,9 @@
+
 import Foundation
+import OpenTelemetrySdk
 
 internal let runtimeVersion = ProcessInfo().operatingSystemVersionString
-// TODO: This can't be set programmatically for now, because it is incorrect upstream.
-// We should fix this here:
-// https://github.com/open-telemetry/opentelemetry-swift/blob/32ea291d791f5a0652630fc176b73d1639074046/Sources/OpenTelemetrySdk/Version.swift#L9
-internal let otlpVersion = "1.10.1"
+internal let otlpVersion = Resource.OTEL_SWIFT_SDK_VERSION
 
 // Constants for keys and defaults in HoneycombOptions.
 
@@ -160,7 +159,7 @@ extension Dictionary {
 /// https://github.com/honeycombio/specs/blob/main/specs/otel-sdk-distro.md
 /// https://opentelemetry.io/docs/languages/sdk-configuration/general/
 /// https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/
-public class HoneycombOptions {
+public struct HoneycombOptions {
     let tracesApiKey: String
     let metricsApiKey: String
     let logsApiKey: String

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import OpenTelemetrySdk
 

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -188,59 +188,6 @@ public struct HoneycombOptions {
     let metricsProtocol: OTLPProtocol
     let logsProtocol: OTLPProtocol
 
-    init(
-        tracesApiKey: String,
-        metricsApiKey: String,
-        logsApiKey: String,
-        dataset: String?,
-        metricsDataset: String?,
-        tracesEndpoint: String,
-        metricsEndpoint: String,
-        logsEndpoint: String,
-        sampleRate: Int,
-        debug: Bool,
-        serviceName: String,
-        resourceAttributes: [String: String],
-        tracesSampler: String,
-        tracesSamplerArg: String?,
-        propagators: String,
-        tracesHeaders: [String: String],
-        metricsHeaders: [String: String],
-        logsHeaders: [String: String],
-        tracesTimeout: TimeInterval,
-        metricsTimeout: TimeInterval,
-        logsTimeout: TimeInterval,
-        tracesProtocol: OTLPProtocol,
-        metricsProtocol: OTLPProtocol,
-        logsProtocol: OTLPProtocol
-    ) {
-
-        self.tracesApiKey = tracesApiKey
-        self.metricsApiKey = metricsApiKey
-        self.logsApiKey = logsApiKey
-        self.dataset = dataset
-        self.metricsDataset = metricsDataset
-        self.tracesEndpoint = tracesEndpoint
-        self.metricsEndpoint = metricsEndpoint
-        self.logsEndpoint = logsEndpoint
-        self.sampleRate = sampleRate
-        self.debug = debug
-        self.serviceName = serviceName
-        self.resourceAttributes = resourceAttributes
-        self.tracesSampler = tracesSampler
-        self.tracesSamplerArg = tracesSamplerArg
-        self.propagators = propagators
-        self.tracesHeaders = tracesHeaders
-        self.metricsHeaders = metricsHeaders
-        self.logsHeaders = logsHeaders
-        self.tracesTimeout = tracesTimeout
-        self.metricsTimeout = metricsTimeout
-        self.logsTimeout = logsTimeout
-        self.tracesProtocol = tracesProtocol
-        self.metricsProtocol = metricsProtocol
-        self.logsProtocol = logsProtocol
-    }
-
     public class Builder {
         private var apiKey: String? = nil
         private var tracesApiKey: String? = nil

--- a/Workspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Workspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "915791055293f8edcf6a57b42d26c936298647969828631e64f1ef8a396aeaf5",
+  "originHash" : "f5d6922243fdb0495a47b043b36995028870560219cb8c6ece106a6e686c8363",
   "pins" : [
     {
       "identity" : "grpc-swift",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
       "state" : {
-        "revision" : "0dd37c4a14a6aeeb131eea40a13cb3832c7c6a97",
-        "version" : "1.10.1"
+        "revision" : "f2315d8646432c02338960e85b5fe20417ad6d8d",
+        "version" : "1.12.1"
       }
     },
     {


### PR DESCRIPTION
## Which problem is this PR solving?

These are various small cleanups as we prepare for an eventual beta release.

## Short description of the changes

* Updated CHANGELOG.md with all changes since last release.
* Updated OTel to 1.12.1.
* Updated `RELEASING.md` to better match this repo's process.
* Removed old TODOs from `Honeycomb.swift`. Some were fixed already, and others were deprioritized.
* Changed debug options to print _all_ options, rather than just a handful.
* Stopped hard-coding `otlpVersion` since that's fixed upstream.
* Removed a constructor that is now redundant for `HoneycombOptions`.

## How to verify that this has the expected result

Smoke tests and unit tests still pass. Manually verified debug output is reasonable.