### PR TITLE
feat: Add current screen and path to UIKit view events

### DIFF
--- a/Sources/Honeycomb/UIKit/UIViewController.swift
+++ b/Sources/Honeycomb/UIKit/UIViewController.swift
@@ -32,10 +32,10 @@
         }
 
         private func setAttributes(span: Span, className: String, animated: Bool) {
-        
+
             span.setAttribute(key: "screen.name", value: self.viewName)
             span.setAttribute(key: "screen.path", value: self.viewStack().joined(separator: "/"))
-            
+
             if let nibName = self.nibName {
                 span.setAttribute(key: "view.nibName", value: nibName)
             }

--- a/Sources/Honeycomb/UIKit/UIViewController.swift
+++ b/Sources/Honeycomb/UIKit/UIViewController.swift
@@ -32,9 +32,10 @@
         }
 
         private func setAttributes(span: Span, className: String, animated: Bool) {
-            if let title = self.title {
-                span.setAttribute(key: "view.title", value: title)
-            }
+        
+            span.setAttribute(key: "screen.name", value: self.viewName)
+            span.setAttribute(key: "screen.path", value: self.viewStack().joined(separator: "/"))
+            
             if let nibName = self.nibName {
                 span.setAttribute(key: "view.nibName", value: nibName)
             }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -194,28 +194,28 @@ mk_diag_attr() {
 
 @test "UIViewController attributes are correct" {
     result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
-        | jq "select (.key == \"view.class\")" \
-        | jq "select (.value.stringValue == \"SmokeTest.UIKitMenuViewController\").value.stringValue" \
+        | jq "select (.key == \"screen.name\")" \
+        | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq)
-    assert_equal "$result" '"SmokeTest.UIKitMenuViewController"'
+    assert_equal "$result" '"UIKit Menu"'
 
     result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidDisappear \
-        | jq "select (.key == \"view.class\")" \
-        | jq "select (.value.stringValue == \"SmokeTest.UIKitMenuViewController\").value.stringValue" \
+        | jq "select (.key == \"screen.name\")" \
+        | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq)
-    assert_equal "$result" '"SmokeTest.UIKitMenuViewController"'
+    assert_equal "$result" '"UIKit Menu"'
     
         result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
-        | jq "select (.key == \"view.class\")" \
-        | jq "select (.value.stringValue == \"SmokeTest.UIKitScreenViewController\").value.stringValue" \
+        | jq "select (.key == \"screen.name\")" \
+        | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq)
-    assert_equal "$result" '"SmokeTest.UIKitScreenViewController"'
+    assert_equal "$result" '"UI KIT SCREEN OVERRIDE"'
 
     result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidDisappear \
-        | jq "select (.key == \"view.class\")" \
-        | jq "select (.value.stringValue == \"SmokeTest.UIKitScreenViewController\").value.stringValue" \
+        | jq "select (.key == \"screen.name\")" \
+        | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq)
-    assert_equal "$result" '"SmokeTest.UIKitScreenViewController"'
+    assert_equal "$result" '"UI KIT SCREEN OVERRIDE"'
 }
 
 @test "UITabView attributes are correct" {

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -110,27 +110,6 @@ assert_equal() {
 	fi
 }
 
-# Fail and display details if the expected value is not a substring
-# of the actual result. Details include both values.
-#
-# Inspired by bats-assert * bats-support, but dramatically simplified
-# Arguments:
-# $1 - actual result
-# $2 - expected result
-assert_contains() {
-    	if [[ $1 != *"$2"* ]]; then
-		{
-			echo
-			echo "-- 💥 values are not equal 💥 --"
-			echo "expected : $2"
-			echo "actual   : $1"
-			echo "--"
-			echo
-		} >&2 # output error to STDERR
-		return 1
-	fi
-}
-
 # Fail and display details if the actual value is empty.
 # Arguments: $1 - actual result
 assert_not_empty_string() {

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -110,6 +110,27 @@ assert_equal() {
 	fi
 }
 
+# Fail and display details if the expected value is not a substring
+# of the actual result. Details include both values.
+#
+# Inspired by bats-assert * bats-support, but dramatically simplified
+# Arguments:
+# $1 - actual result
+# $2 - expected result
+assert_contains() {
+    	if [[ $1 != *"$2"* ]]; then
+		{
+			echo
+			echo "-- 💥 values are not equal 💥 --"
+			echo "expected : $2"
+			echo "actual   : $1"
+			echo "--"
+			echo
+		} >&2 # output error to STDERR
+		return 1
+	fi
+}
+
 # Fail and display details if the actual value is empty.
 # Arguments: $1 - actual result
 assert_not_empty_string() {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #<enter issue here>

https://app.asana.com/0/1207924506367446/1208828193388887/f

## Short description of the changes

adds `screen.path` and `screen.name` to `viewDidAppear` and `viewDidDissapear` methods

## How to verify that this has the expected result

WIP: adding automated test to ensure
