### PR TITLE
feat: actually expose the deterministic sampler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,7 @@ Please see our [OSS process document](https://github.com/honeycombio/home/blob/m
 ## Short description of the changes
 
 ## How to verify that this has the expected result
+
+---
+
+- [ ] Changelog is updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ### New Features
 
+* Add deterministic sampler (configurable through the `sampleRate` option)
 * Emit session.id using default SessionManager
 * Update to OpenTelemetry Swift 1.12.1.
 * Auto-instrumentation of URLSession.

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -110,6 +110,7 @@ public class Honeycomb {
                 )
             )
             .with(resource: resource)
+            .with(sampler: HoneycombDeterministicSampler(sampleRate: options.sampleRate))
             .build()
 
         // Metrics

--- a/Sources/Honeycomb/HoneycombDeterministicSampler.swift
+++ b/Sources/Honeycomb/HoneycombDeterministicSampler.swift
@@ -11,10 +11,13 @@ class HoneycombDeterministicSampler: Sampler {
 
         switch sampleRate {
         case Int.min..<1:
+            print("Sample rate too low, not emitting any spans!")
             inner = Samplers.alwaysOff
         case 1:
+            print("Not sampling, emitting all spans")
             inner = Samplers.alwaysOn
         default:
+            print("Sampling enabled: emitting every 1 in \(sampleRate) spans")
             inner = Samplers.traceIdRatio(ratio: 1.0 / Double(sampleRate))
         }
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -105,7 +105,8 @@ mk_attr() {
 
   result=$(attributes_from_span_named $scope $span | jq .key | sort | uniq)
 
-   assert_equal "$result" '"screen.name"
+   assert_equal "$result" '"SampleRate"
+"screen.name"
 "screen.path"
 "session.id"
 "signpost.category"


### PR DESCRIPTION
## Which problem is this PR solving?

Exposes sampling functionality (basically the same as https://github.com/honeycombio/honeycomb-opentelemetry-android/pull/34)

## Short description of the changes

We already had a `sampleRate` option and the code for a deterministic sampler, this PR just ties them together.

## How to verify that this has the expected result
🤔 

Existing smoke tests pass, so we know the default value (ie. `1`) does not apply any sampling. I'm open to suggestions on how to test actual sample rates. 