### PR TITLE
rel: Prep for v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,26 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
-## 0.0.2-alpha (2025-02-11)
+## 0.0.3-alpha (2025-02-11)
 
 ### New Features
 
-* Add deterministic sampler (configurable through the `sampleRate` option)
-* Emit session.id using default SessionManager
 * Update to OpenTelemetry Swift 1.12.1.
-* Auto-instrumentation of URLSession.
+* Add deterministic sampler (configurable through the `sampleRate` option)
 * Auto-instrumentation of navigation in UI Kit.
+* Emit session.id using default SessionManager
+* Include `telemetry.sdk.language` and other default resource fields
+
+## 0.0.2-alpha (2024-12-20)
+
+### New Features
+
+* Update to OpenTelemetry Swift 1.10.1.
+* Auto-instrumentation of URLSession.
 * Auto-instrumentation of "clicks" and touch events in UI Kit.
 * Manual instrumentation of SwiftUI navigation.
 * Manual instrumentation of SwiftUI view rendering.
+* Add baggage span processor
 
 ## 0.0.1-alpha (2024-09-27)
 

--- a/Sources/Honeycomb/HoneycombVersion.swift
+++ b/Sources/Honeycomb/HoneycombVersion.swift
@@ -1,4 +1,4 @@
 import Foundation
 
 // TODO: Make a build script that injects this.
-internal let honeycombLibraryVersion = "0.0.2-alpha"
+internal let honeycombLibraryVersion = "0.0.3-alpha"


### PR DESCRIPTION
In Dec I did [a release for `v0.0.2`](https://github.com/honeycombio/honeycomb-opentelemetry-swift/releases/tag/v0.0.2-alpha) but failed to update the internal version number or the changelog. 

This PR fixes the changelog and bumps the internal version to `v0.0.3-alpha`.