### PR TITLE
fix: move session in notification from "object" to "userInfo"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+### Fixes
+
+* Move `HoneycombSession` in `NotificationCenter` from being the sender to `userInfo`.
+
 ## 0.0.3-alpha (2025-02-11)
 
 ### New Features
 
 * Update to OpenTelemetry Swift 1.12.1.
-* Add deterministic sampler (configurable through the `sampleRate` option)
+* Add deterministic sampler (configurable through the `sampleRate` option).
 * Auto-instrumentation of navigation in UI Kit.
-* Emit session.id using default SessionManager
-* Include `telemetry.sdk.language` and other default resource fields
+* Emit session.id using default SessionManager.
+* Include `telemetry.sdk.language` and other default resource fields.
 
 ## 0.0.2-alpha (2024-12-20)
 
@@ -21,7 +25,7 @@ Honeycomb OpenTelemetry SDK Changelog
 * Auto-instrumentation of "clicks" and touch events in UI Kit.
 * Manual instrumentation of SwiftUI navigation.
 * Manual instrumentation of SwiftUI view rendering.
-* Add baggage span processor
+* Add baggage span processor.
 
 ## 0.0.1-alpha (2024-09-27)
 

--- a/Examples/SmokeTest/SmokeTest/ContentView.swift
+++ b/Examples/SmokeTest/SmokeTest/ContentView.swift
@@ -118,7 +118,9 @@ struct ContentView: View {
                 object: nil,
                 queue: .main
             ) { notification in
-                guard let session = notification.object as? HoneycombSession else { return }
+                guard let session = notification.userInfo?["session"] as? HoneycombSession else {
+                    return
+                }
                 updateSessionInfo(session: session)
             }
         }

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ You can call `HoneycombOptions.setSessionTimeout` to set the timeout duration.
 
 You can subscribe to `.sessionStarted` and `sessionEnded` with `NotificationCenter` to be notified of session start and end events. 
 For `.sessionStarted`:
-* `.object` contains the session just created
-* userInfo["previousSession"] contains the previous session or `nil` if there is no previous session. 
+* `userInfo["session"]` contains the session just created
+* `userInfo["previousSession"]` contains the previous session or `nil` if there is no previous session. 
 For `.sessionEnded`:
-* `.object` contains the session just ended.
+* `userInfo["previousSession"]` contains the session just ended.
 
 ## Manual Instrumentation
 ### SwiftUI View Instrumentation

--- a/Sources/Honeycomb/Session/HoneycombSessionManager.swift
+++ b/Sources/Honeycomb/Session/HoneycombSessionManager.swift
@@ -10,7 +10,7 @@ extension Notification.Name {
     public static let sessionEnded = Notification.Name("io.honeycomb.app.session.ended")
 }
 
-public class HoneycombSessionManager {
+class HoneycombSessionManager {
     private var sessionStorage: SessionStorage
     private var currentSession: HoneycombSession?
     private var debug: Bool
@@ -48,7 +48,7 @@ public class HoneycombSessionManager {
         return elapsedTime >= sessionLifetime
     }
 
-    public var sessionId: String {
+    var sessionId: String {
         // If there is no current session make a new one
         if self.currentSession == nil {
             let newSession = HoneycombSession(

--- a/Sources/Honeycomb/Session/HoneycombSessionManager.swift
+++ b/Sources/Honeycomb/Session/HoneycombSessionManager.swift
@@ -48,7 +48,7 @@ public class HoneycombSessionManager {
         return elapsedTime >= sessionLifetime
     }
 
-    var sessionId: String {
+    public var sessionId: String {
         // If there is no current session make a new one
         if self.currentSession == nil {
             let newSession = HoneycombSession(
@@ -96,10 +96,11 @@ public class HoneycombSessionManager {
             dump(newSession, name: "Current session")
         }
         var userInfo: [String: Any] = [:]
+        userInfo["session"] = newSession
         userInfo["previousSession"] = previousSession
         NotificationCenter.default.post(
             name: Notification.Name.sessionStarted,
-            object: newSession,
+            object: self,
             userInfo: userInfo
         )
 
@@ -112,7 +113,13 @@ public class HoneycombSessionManager {
             )
             dump(session, name: "Session")
         }
-        NotificationCenter.default.post(name: Notification.Name.sessionEnded, object: session)
+        var userInfo: [String: Any] = [:]
+        userInfo["previousSession"] = session
+        NotificationCenter.default.post(
+            name: Notification.Name.sessionEnded,
+            object: self,
+            userInfo: userInfo
+        )
     }
 
 }

--- a/Tests/Honeycomb/HoneycombSessionManagerTests.swift
+++ b/Tests/Honeycomb/HoneycombSessionManagerTests.swift
@@ -18,6 +18,7 @@ final class HoneycombSessionManagerTests: XCTestCase {
     var sessionManager: HoneycombSessionManager!
     var storage: SessionStorage!
     var sessionLifetimeSeconds = TimeInterval(60 * 60 * 4)
+
     override func setUp() {
         super.setUp()
         storage = SessionStorage()
@@ -162,8 +163,8 @@ final class HoneycombSessionManagerTests: XCTestCase {
     func testOnSessionStartedOnStartup() {
         let expectation = self.expectation(forNotification: .sessionStarted, object: nil) {
             notification in
-            if let session = notification.object as? HoneycombSession {
-                XCTAssertNil(notification.userInfo!["previousSession"])
+            XCTAssertNil(notification.userInfo?["previousSession"])
+            if let session = notification.userInfo?["session"] as? HoneycombSession {
                 XCTAssertNotNil(session.id)
                 XCTAssertNotNil(session.startTimestamp)
                 return true
@@ -219,7 +220,8 @@ final class HoneycombSessionManagerTests: XCTestCase {
         _ = sessionManager.sessionId
 
         wait(for: [expectation, endExpectation], timeout: 1)
-        guard let session = startNotifications.last?.object as? HoneycombSession else {
+        guard let session = startNotifications.last?.userInfo?["session"] as? HoneycombSession
+        else {
             XCTFail("Session not present on start session notification")
             return
         }
@@ -236,7 +238,10 @@ final class HoneycombSessionManagerTests: XCTestCase {
         XCTAssertNotNil(previousSession.id)
         XCTAssertNotNil(previousSession.startTimestamp)
 
-        guard let endedSession = endNotifications.last?.object as? HoneycombSession else {
+        guard
+            let endedSession = endNotifications.last?.userInfo?["previousSession"]
+                as? HoneycombSession
+        else {
             XCTFail("Session not present on end session notification")
             return
         }


### PR DESCRIPTION
## Which problem is this PR solving?

Before this PR, `SessionManager` was sending notifications when the session changes with a `HoneycombSession` as the `object` of the notification. But `object` is poorly-named, and is actually intended to be the _sender_ of the notification. Its use is for filtering notifications when setting up observers. But for something like a session, there's a new session every time, so filtering for a specific one doesn't really work. The sender should be the `SessionManager`, and the session itself should be moved to `userInfo`.

## Short description of the changes

* Moves the session to `userInfo["session"]`, and changes `object` to be the `SessionManager`.
* Marks `SessionManager` as private, since all of its members were private anyway.

## How to verify that this has the expected result

The tests have been updated.

- [✅] Changelog is updated
