### PR TITLE
feat: Add cocopods frameworks for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Honeycomb OpenTelemetry SDK Changelog
 * Manual instrumentation of SwiftUI navigation.
 * Manual instrumentation of SwiftUI view rendering.
 * Add baggage span processor.
+* Package is now available on Cocoapods.
 
 ## 0.0.1-alpha (2024-09-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
-## 0.0.5-alpha
+### New Features
 
-* Add a `setSpanProcessor()` function to `HoneycombOptions` builder to allow clients to supply custom span processors.
+* Package is now available on Cocoapods.
 
 ## 0.0.4-alpha
 
@@ -32,7 +32,6 @@ Honeycomb OpenTelemetry SDK Changelog
 * Manual instrumentation of SwiftUI navigation.
 * Manual instrumentation of SwiftUI view rendering.
 * Add baggage span processor.
-* Package is now available on Cocoapods.
 
 ## 0.0.1-alpha (2024-09-27)
 

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -1,12 +1,9 @@
 import Foundation
-import GRPC
 import MetricKit
-import NIO
 import OpenTelemetryApi
-import OpenTelemetryProtocolExporterCommon
-import OpenTelemetryProtocolExporterGrpc
-import OpenTelemetryProtocolExporterHttp
 import OpenTelemetrySdk
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetryProtocolExporterHttp
 import ResourceExtension
 import StdoutExporter
 import SwiftUI
@@ -68,19 +65,7 @@ public class Honeycomb {
         // Traces
 
         var traceExporter: SpanExporter
-        if options.tracesProtocol == .grpc {
-            // Break down the URL into host and port, or use defaults from the spec.
-            let host = tracesEndpoint.host ?? "api.honeycomb.io"
-            let port = tracesEndpoint.port ?? 4317
-
-            let channel =
-                ClientConnection.usingPlatformAppropriateTLS(
-                    for: MultiThreadedEventLoopGroup(numberOfThreads: 1)
-                )
-                .connect(host: host, port: port)
-
-            traceExporter = OtlpTraceExporter(channel: channel, config: otlpTracesConfig)
-        } else if options.tracesProtocol == .httpJSON {
+        if options.tracesProtocol == .httpJSON {
             throw HoneycombOptionsError.unsupportedProtocol("http/json")
         } else {
             traceExporter = OtlpHttpTraceExporter(
@@ -121,19 +106,7 @@ public class Honeycomb {
         // Metrics
 
         var metricExporter: MetricExporter
-        if options.metricsProtocol == .grpc {
-            // Break down the URL into host and port, or use defaults from the spec.
-            let host = metricsEndpoint.host ?? "api.honeycomb.io"
-            let port = metricsEndpoint.port ?? 4317
-
-            let channel =
-                ClientConnection.usingPlatformAppropriateTLS(
-                    for: MultiThreadedEventLoopGroup(numberOfThreads: 1)
-                )
-                .connect(host: host, port: port)
-
-            metricExporter = OtlpMetricExporter(channel: channel, config: otlpMetricsConfig)
-        } else if options.metricsProtocol == .httpJSON {
+        if options.metricsProtocol == .httpJSON {
             throw HoneycombOptionsError.unsupportedProtocol("http/json")
         } else {
             metricExporter = OtlpHttpMetricExporter(
@@ -151,19 +124,7 @@ public class Honeycomb {
         // Logs
 
         var logExporter: LogRecordExporter
-        if options.logsProtocol == .grpc {
-            // Break down the URL into host and port, or use defaults from the spec.
-            let host = logsEndpoint.host ?? "api.honeycomb.io"
-            let port = logsEndpoint.port ?? 4317
-
-            let channel =
-                ClientConnection.usingPlatformAppropriateTLS(
-                    for: MultiThreadedEventLoopGroup(numberOfThreads: 1)
-                )
-                .connect(host: host, port: port)
-
-            logExporter = OtlpLogExporter(channel: channel, config: otlpLogsConfig)
-        } else if options.logsProtocol == .httpJSON {
+        if options.logsProtocol == .httpJSON {
             throw HoneycombOptionsError.unsupportedProtocol("http/json")
         } else {
             logExporter = OtlpHttpLogExporter(endpoint: logsEndpoint, config: otlpLogsConfig)

--- a/honeycomb-opentelemetry-swift.podspec
+++ b/honeycomb-opentelemetry-swift.podspec
@@ -11,21 +11,11 @@ Pod::Spec.new do |s|
   s.version          = '0.1.0'
   s.summary          = 'Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) on iOS and macOS.'
 
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!
-
-  s.description      = <<-DESC
-TODO: Add long description of the pod here.
-                       DESC
-
   s.homepage         = 'https://github.com/honeycombio/honeycomb-opentelemetry-swift'
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.author           = { '' => '' }
-  s.source           = { :git => 'https://github.com/honeycombio/honeycomb-opentelemetry-swift', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/honeycombio/honeycomb-opentelemetry-swift.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = "13.0"
   s.tvos.deployment_target = "13.0"

--- a/honeycomb-opentelemetry-swift.podspec
+++ b/honeycomb-opentelemetry-swift.podspec
@@ -35,4 +35,6 @@ Pod::Spec.new do |s|
   s.dependency 'OpenTelemetry-Swift-Protocol-Exporter-Http', '~> 1.13.0'
   s.dependency 'OpenTelemetry-Swift-SdkResourceExtension', '~> 1.13.0'
   s.dependency 'OpenTelemetry-Swift-StdoutExporter', '~> 1.13.0'
+
+  s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name Honeycomb -package-name honeycomb_opentelemetry_swift" }
 end

--- a/honeycomb-opentelemetry-swift.podspec
+++ b/honeycomb-opentelemetry-swift.podspec
@@ -1,0 +1,34 @@
+#
+# Be sure to run `pod lib lint honeycomb-opentelemetry-swift.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'honeycomb-opentelemetry-swift'
+  s.version          = '0.1.0'
+  s.summary          = 'Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) on iOS and macOS.'
+
+# This description is used to generate tags and improve search results.
+#   * Think: What does it do? Why did you write it? What is the focus?
+#   * Try to keep it short, snappy and to the point.
+#   * Write the description between the DESC delimiters below.
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+
+  s.description      = <<-DESC
+TODO: Add long description of the pod here.
+                       DESC
+
+  s.homepage         = 'https://github.com/honeycombio/honeycomb-opentelemetry-swift'
+  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
+  s.author           = { '' => '' }
+  s.source           = { :git => 'https://github.com/honeycombio/honeycomb-opentelemetry-swift', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '10.0'
+
+  s.source_files = 'Sources/Honeycomb/**/*.swift'
+  
+end

--- a/honeycomb-opentelemetry-swift.podspec
+++ b/honeycomb-opentelemetry-swift.podspec
@@ -27,8 +27,22 @@ TODO: Add long description of the pod here.
   s.author           = { '' => '' }
   s.source           = { :git => 'https://github.com/honeycombio/honeycomb-opentelemetry-swift', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = "13.0"
+  s.tvos.deployment_target = "13.0"
+  s.watchos.deployment_target = "6.0"
 
   s.source_files = 'Sources/Honeycomb/**/*.swift'
   
+  # s.resource_bundles = {
+  #   'honeycomb-opentelemetry-swift' => ['honeycomb-opentelemetry-swift/Assets/*.png']
+  # }
+
+  # s.public_header_files = 'Pod/Classes/**/*.h'
+  # s.frameworks = 'UIKit', 'MapKit'
+  s.dependency 'OpenTelemetry-Swift-Api', '~> 1.13.0'
+  s.dependency 'OpenTelemetry-Swift-Sdk', '~> 1.13.0'
+  s.dependency 'OpenTelemetry-Swift-Protocol-Exporter-Common', '~> 1.13.0'
+  s.dependency 'OpenTelemetry-Swift-Protocol-Exporter-Http', '~> 1.13.0'
+  s.dependency 'OpenTelemetry-Swift-SdkResourceExtension', '~> 1.13.0'
+  s.dependency 'OpenTelemetry-Swift-StdoutExporter', '~> 1.13.0'
 end


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #<enter issue here>

## Short description of the changes

Adds coccoapods `podspec` file to allow us to publish this on the cocoapods repo. 

This also conditionally disables gRPC protocol if the grpc libraries are unavailable. This was necessary as there is no official `grpc-swift` package available on cocoapods upon which upstream otel-swift depends.

## How to verify that this has the expected result

## TODO:

- Publishing this to cocoapods (preferably as part of release)
- ~~Upstream changes merged (so that people can download the otel dependencies).~~

---

- [X] Changelog is updated
