### PR TITLE
feat: expose `addSpanProcessor()` api for custom span processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* Add a `setSpanProcessor()` function to `HoneycombOptions` builder to allow clients to supply custom span processors.
+
 ## 0.0.4-alpha
 
 ### Fixes

--- a/Examples/SmokeTest/SmokeTest.xcodeproj/project.pbxproj
+++ b/Examples/SmokeTest/SmokeTest.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		366309122CE51EF000B97612 /* UIKitViewStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 366309112CE51EF000B97612 /* UIKitViewStoryboard.storyboard */; };
 		452B71DD2CE52C8600C27FB2 /* ViewInstrumentationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452B71DC2CE52C8600C27FB2 /* ViewInstrumentationView.swift */; };
 		452B71E12CE6A52600C27FB2 /* NavigationExamplesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452B71E02CE6A52600C27FB2 /* NavigationExamplesView.swift */; };
+		45F3D2892D6903C9007C2225 /* SampleSpanProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F3D2882D6903C3007C2225 /* SampleSpanProcessor.swift */; };
 		AF6DEFEA2C8D3CE000363027 /* SmokeTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6DEFE92C8D3CE000363027 /* SmokeTestApp.swift */; };
 		AF6DEFEC2C8D3CE000363027 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6DEFEB2C8D3CE000363027 /* ContentView.swift */; };
 		AF6DEFEE2C8D3CE100363027 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AF6DEFED2C8D3CE100363027 /* Assets.xcassets */; };
@@ -45,6 +46,7 @@
 		366309112CE51EF000B97612 /* UIKitViewStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UIKitViewStoryboard.storyboard; sourceTree = "<group>"; };
 		452B71DC2CE52C8600C27FB2 /* ViewInstrumentationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewInstrumentationView.swift; sourceTree = "<group>"; };
 		452B71E02CE6A52600C27FB2 /* NavigationExamplesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationExamplesView.swift; sourceTree = "<group>"; };
+		45F3D2882D6903C3007C2225 /* SampleSpanProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleSpanProcessor.swift; sourceTree = "<group>"; };
 		AF6DEFE62C8D3CE000363027 /* SmokeTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SmokeTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF6DEFE92C8D3CE000363027 /* SmokeTestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTestApp.swift; sourceTree = "<group>"; };
 		AF6DEFEB2C8D3CE000363027 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 		AF6DEFE82C8D3CE000363027 /* SmokeTest */ = {
 			isa = PBXGroup;
 			children = (
+				45F3D2882D6903C3007C2225 /* SampleSpanProcessor.swift */,
 				AFA277C32CC71DF5007F8A46 /* NetworkView.swift */,
 				452B71E02CE6A52600C27FB2 /* NavigationExamplesView.swift */,
 				AFA0BA5B2C8E12E700F54611 /* MetricKitTestHelpers.swift */,
@@ -289,6 +292,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45F3D2892D6903C9007C2225 /* SampleSpanProcessor.swift in Sources */,
 				AF6DEFEC2C8D3CE000363027 /* ContentView.swift in Sources */,
 				AFA277C42CC71DF7007F8A46 /* NetworkView.swift in Sources */,
 				366309102CE51BDC00B97612 /* UIKitView.swift in Sources */,

--- a/Examples/SmokeTest/SmokeTest/SampleSpanProcessor.swift
+++ b/Examples/SmokeTest/SmokeTest/SampleSpanProcessor.swift
@@ -15,12 +15,11 @@ internal class SampleSpanProcessor: SpanProcessor {
             value: "extra metadata"
         )
     }
-    
+
     func onEnd(span: any OpenTelemetrySdk.ReadableSpan) {}
-    
+
     func shutdown(explicitTimeout: TimeInterval?) {}
-    
+
     func forceFlush(timeout: TimeInterval?) {}
-    
-        
+
 }

--- a/Examples/SmokeTest/SmokeTest/SampleSpanProcessor.swift
+++ b/Examples/SmokeTest/SmokeTest/SampleSpanProcessor.swift
@@ -1,0 +1,26 @@
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+internal class SampleSpanProcessor: SpanProcessor {
+    public let isStartRequired = true
+    public let isEndRequired = false
+
+    public func onStart(
+        parentContext: SpanContext?,
+        span: any ReadableSpan
+    ) {
+        span.setAttribute(
+            key: "app.metadata",
+            value: "extra metadata"
+        )
+    }
+    
+    func onEnd(span: any OpenTelemetrySdk.ReadableSpan) {}
+    
+    func shutdown(explicitTimeout: TimeInterval?) {}
+    
+    func forceFlush(timeout: TimeInterval?) {}
+    
+        
+}

--- a/Examples/SmokeTest/SmokeTest/SmokeTestApp.swift
+++ b/Examples/SmokeTest/SmokeTest/SmokeTestApp.swift
@@ -11,6 +11,7 @@ struct SmokeTestApp: App {
                 .setServiceName("ios-test")
                 .setDebug(true)
                 .setSessionTimeout(10)
+                .setSpanProcessor(SampleSpanProcessor())
                 .build()
             try Honeycomb.configure(options: options)
         } catch {

--- a/Sources/Honeycomb/CompositeSpanProcessor.swift
+++ b/Sources/Honeycomb/CompositeSpanProcessor.swift
@@ -6,29 +6,32 @@ internal class CompositeSpanProcessor: SpanProcessor {
     private var spanProcessors: [SpanProcessor] = []
     var isStartRequired: Bool = false
     var isEndRequired: Bool = false
-    
+
     func addSpanProcessor(_ spanProcessor: SpanProcessor) {
         spanProcessors.append(spanProcessor)
         isStartRequired = spanProcessors.contains(where: { $0.isStartRequired })
         isEndRequired = spanProcessors.contains(where: { $0.isEndRequired })
     }
 
-    func onStart(parentContext: OpenTelemetryApi.SpanContext?, span: any OpenTelemetrySdk.ReadableSpan) {
+    func onStart(
+        parentContext: OpenTelemetryApi.SpanContext?,
+        span: any OpenTelemetrySdk.ReadableSpan
+    ) {
         spanProcessors.forEach({ $0.onStart(parentContext: parentContext, span: span) })
     }
-    
+
     func onEnd(span: any OpenTelemetrySdk.ReadableSpan) {
         for var spanProcessor in spanProcessors {
             spanProcessor.onEnd(span: span)
         }
     }
-    
+
     func shutdown(explicitTimeout: TimeInterval?) {
         for var spanProcessor in spanProcessors {
             spanProcessor.shutdown(explicitTimeout: explicitTimeout)
         }
     }
-    
+
     func forceFlush(timeout: TimeInterval?) {
         for spanProcessor in spanProcessors {
             spanProcessor.forceFlush(timeout: timeout)

--- a/Sources/Honeycomb/CompositeSpanProcessor.swift
+++ b/Sources/Honeycomb/CompositeSpanProcessor.swift
@@ -4,13 +4,15 @@ import OpenTelemetrySdk
 
 internal class CompositeSpanProcessor: SpanProcessor {
     private var spanProcessors: [SpanProcessor] = []
-    var isStartRequired: Bool = false
-    var isEndRequired: Bool = false
+    var isStartRequired: Bool {
+        spanProcessors.contains(where: { $0.isStartRequired })
+    }
+    var isEndRequired: Bool {
+        spanProcessors.contains(where: { $0.isEndRequired })
+    }
 
     func addSpanProcessor(_ spanProcessor: SpanProcessor) {
         spanProcessors.append(spanProcessor)
-        isStartRequired = spanProcessors.contains(where: { $0.isStartRequired })
-        isEndRequired = spanProcessors.contains(where: { $0.isEndRequired })
     }
 
     func onStart(

--- a/Sources/Honeycomb/CompositeSpanProcessor.swift
+++ b/Sources/Honeycomb/CompositeSpanProcessor.swift
@@ -1,0 +1,37 @@
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+internal class CompositeSpanProcessor: SpanProcessor {
+    private var spanProcessors: [SpanProcessor] = []
+    var isStartRequired: Bool = false
+    var isEndRequired: Bool = false
+    
+    func addSpanProcessor(_ spanProcessor: SpanProcessor) {
+        spanProcessors.append(spanProcessor)
+        isStartRequired = spanProcessors.contains(where: { $0.isStartRequired })
+        isEndRequired = spanProcessors.contains(where: { $0.isEndRequired })
+    }
+
+    func onStart(parentContext: OpenTelemetryApi.SpanContext?, span: any OpenTelemetrySdk.ReadableSpan) {
+        spanProcessors.forEach({ $0.onStart(parentContext: parentContext, span: span) })
+    }
+    
+    func onEnd(span: any OpenTelemetrySdk.ReadableSpan) {
+        for var spanProcessor in spanProcessors {
+            spanProcessor.onEnd(span: span)
+        }
+    }
+    
+    func shutdown(explicitTimeout: TimeInterval?) {
+        for var spanProcessor in spanProcessors {
+            spanProcessor.shutdown(explicitTimeout: explicitTimeout)
+        }
+    }
+    
+    func forceFlush(timeout: TimeInterval?) {
+        for spanProcessor in spanProcessors {
+            spanProcessor.forceFlush(timeout: timeout)
+        }
+    }
+}

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -95,7 +95,12 @@ public class Honeycomb {
             } else {
                 traceExporter
             }
-        let spanProcessor = BatchSpanProcessor(spanExporter: spanExporter)
+
+        let spanProcessor = CompositeSpanProcessor()
+        spanProcessor.addSpanProcessor(BatchSpanProcessor(spanExporter: spanExporter))
+        if let clientSpanProcessor = options.spanProcessor {
+            spanProcessor.addSpanProcessor(clientSpanProcessor)
+        }
 
         let baggageSpanProcessor = HoneycombBaggageSpanProcessor(filter: { _ in true })
 

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -187,7 +187,7 @@ public struct HoneycombOptions {
     let tracesProtocol: OTLPProtocol
     let metricsProtocol: OTLPProtocol
     let logsProtocol: OTLPProtocol
-    
+
     let spanProcessor: SpanProcessor?
 
     let sessionTimeout: TimeInterval
@@ -229,7 +229,7 @@ public struct HoneycombOptions {
         private var tracesProtocol: OTLPProtocol? = nil
         private var metricsProtocol: OTLPProtocol? = nil
         private var logsProtocol: OTLPProtocol? = nil
-        
+
         private var spanProcessor: SpanProcessor? = nil
 
         private var sessionTimeout: TimeInterval = TimeInterval(60 * 60 * 4)  // 4 hours
@@ -435,7 +435,7 @@ public struct HoneycombOptions {
             logsProtocol = `protocol`
             return self
         }
-        
+
         public func setSpanProcessor(_ processor: SpanProcessor) -> Builder {
             spanProcessor = `processor`
             return self

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -187,6 +187,8 @@ public struct HoneycombOptions {
     let tracesProtocol: OTLPProtocol
     let metricsProtocol: OTLPProtocol
     let logsProtocol: OTLPProtocol
+    
+    let spanProcessor: SpanProcessor?
 
     let sessionTimeout: TimeInterval
 
@@ -227,6 +229,8 @@ public struct HoneycombOptions {
         private var tracesProtocol: OTLPProtocol? = nil
         private var metricsProtocol: OTLPProtocol? = nil
         private var logsProtocol: OTLPProtocol? = nil
+        
+        private var spanProcessor: SpanProcessor? = nil
 
         private var sessionTimeout: TimeInterval = TimeInterval(60 * 60 * 4)  // 4 hours
 
@@ -431,6 +435,11 @@ public struct HoneycombOptions {
             logsProtocol = `protocol`
             return self
         }
+        
+        public func setSpanProcessor(_ processor: SpanProcessor) -> Builder {
+            spanProcessor = `processor`
+            return self
+        }
 
         public func setSessionTimeout(_ timeout: TimeInterval) -> Builder {
             sessionTimeout = timeout
@@ -541,6 +550,7 @@ public struct HoneycombOptions {
                 tracesProtocol: tracesProtocol ?? `protocol`,
                 metricsProtocol: metricsProtocol ?? `protocol`,
                 logsProtocol: logsProtocol ?? `protocol`,
+                spanProcessor: spanProcessor,
                 sessionTimeout: sessionTimeout
             )
         }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -106,6 +106,7 @@ mk_attr() {
   result=$(attributes_from_span_named $scope $span | jq .key | sort | uniq)
 
    assert_equal "$result" '"SampleRate"
+"app.metadata"
 "screen.name"
 "screen.path"
 "session.id"
@@ -312,4 +313,8 @@ mk_diag_attr() {
 @test "Navigation attributes are correct" {
     result=$(attribute_for_span_key "@honeycombio/instrumentation-view" "View Render" "screen.name" string | uniq)
     assert_equal "$result" '"View Instrumentation"'
+}
+
+@test "Span Processor gets added correctly" {
+    result=$(spans_received | jq ".attributes[] | select (.key == \"app.metadata\").value.stringValue" "screen.name" string | uniq)
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -316,5 +316,5 @@ mk_diag_attr() {
 }
 
 @test "Span Processor gets added correctly" {
-    result=$(spans_received | jq ".attributes[] | select (.key == \"app.metadata\").value.stringValue" "screen.name" string | uniq)
+    result=$(spans_received | jq ".attributes[] | select (.key == \"app.metadata\").value.stringValue" "app.metadata" string | uniq)
 }


### PR DESCRIPTION
## Which problem is this PR solving?
We need some API for clients to provide a custom span processor!

## Short description of the changes

- Adds a `.setSpanProcessor()` method to `HoneycombOptions`
    - `HoneycombOptions` has a `configureFromSource` method that reads values out of a plist file, but I didn't update that. I wasn't sure how we'd pass in a full object with methods and such from a plist file. @beekhc let me know if you have ideas or if you think this is ok.
- Use that when setting up the SDK
- Adds an internal-only CompositeSpanProcessor that allows for multiple span processors
    - should we expose this as well? it might be useful

## How to verify that this has the expected result
- [x] smoke tests pass

---

- [x] Changelog is updated
