### PR TITLE
chore: use reverse url notation for instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* Update instrumentation names to use reverse url notation (`io.honeycomb.instrumentation.*`) instead of `@honeycombio/instrumentation-*` notation. 
+
 ## 0.0.5-alpha
 
 * Add a `setSpanProcessor()` function to `HoneycombOptions` builder to allow clients to supply custom span processors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
-* Update instrumentation names to use reverse url notation (`io.honeycomb.instrumentation.*`) instead of `@honeycombio/instrumentation-*` notation. 
+* Update instrumentation names to use reverse url notation (`io.honeycomb.*`) instead of `@honeycombio/instrumentation-*` notation. 
 * Package is now available on Cocoapods.
 
 ## 0.0.5-alpha

--- a/Examples/SmokeTest/SmokeTest/ContentView.swift
+++ b/Examples/SmokeTest/SmokeTest/ContentView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 private func sendSimpleSpan() {
     let tracerProvider = OpenTelemetry.instance.tracerProvider.get(
-        instrumentationName: "@honeycombio/smoke-test",
+        instrumentationName: "io.honeycomb.smoke-test",
         instrumentationVersion: nil
     )
     let span = tracerProvider.spanBuilder(spanName: "test-span").startSpan()

--- a/Sources/Honeycomb/HoneycombInstrumentedView.swift
+++ b/Sources/Honeycomb/HoneycombInstrumentedView.swift
@@ -1,7 +1,7 @@
 import OpenTelemetryApi
 import SwiftUI
 
-private let honeycombInstrumentedViewName = "io.honeycomb.instrumentation.view"
+private let honeycombInstrumentedViewName = "io.honeycomb.view"
 
 public struct HoneycombInstrumentedView<Content: View>: View {
     private let span: Span

--- a/Sources/Honeycomb/HoneycombInstrumentedView.swift
+++ b/Sources/Honeycomb/HoneycombInstrumentedView.swift
@@ -1,7 +1,7 @@
 import OpenTelemetryApi
 import SwiftUI
 
-private let honeycombInstrumentedViewName = "@honeycombio/instrumentation-view"
+private let honeycombInstrumentedViewName = "io.honeycomb.instrumentation.view"
 
 public struct HoneycombInstrumentedView<Content: View>: View {
     private let span: Span

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -2,7 +2,7 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import SwiftUI
 
-private let navigationInstrumentationName = "io.honeycomb.instrumentation.navigation"
+private let navigationInstrumentationName = "io.honeycomb.navigation"
 private let navigationSpanName = "Navigation"
 private let unencodablePath = "<unencodable path>"
 

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -2,7 +2,7 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import SwiftUI
 
-private let navigationInstrumentationName = "@honeycombio/instrumentation-navigation"
+private let navigationInstrumentationName = "io.honeycomb.instrumentation.navigation"
 private let navigationSpanName = "Navigation"
 private let unencodablePath = "<unencodable path>"
 

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -2,7 +2,7 @@ import Foundation
 import MetricKit
 import OpenTelemetryApi
 
-private let metricKitInstrumentationName = "io.honeycomb.metric-kit"
+private let metricKitInstrumentationName = "io.honeycomb.metrickit"
 
 @available(iOS 13.0, macOS 12.0, *)
 class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -2,7 +2,7 @@ import Foundation
 import MetricKit
 import OpenTelemetryApi
 
-private let metricKitInstrumentationName = "@honeycombio/instrumentation-metric-kit"
+private let metricKitInstrumentationName = "io.honeycomb.instrumentation.metric-kit"
 
 @available(iOS 13.0, macOS 12.0, *)
 class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -2,7 +2,7 @@ import Foundation
 import MetricKit
 import OpenTelemetryApi
 
-private let metricKitInstrumentationName = "io.honeycomb.instrumentation.metric-kit"
+private let metricKitInstrumentationName = "io.honeycomb.metric-kit"
 
 @available(iOS 13.0, macOS 12.0, *)
 class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {

--- a/Sources/Honeycomb/Networking/NetworkInstrumentation.swift
+++ b/Sources/Honeycomb/Networking/NetworkInstrumentation.swift
@@ -3,7 +3,7 @@ import OpenTelemetryApi
 import SwiftUI
 import UIKit
 
-private let urlSessionInstrumentationName = "@honeycombio/instrumentation-urlsession"
+private let urlSessionInstrumentationName = "io.honeycomb.instrumentation.urlsession"
 
 /// Creates a span with attributes for the given http request.
 internal func createSpan(from request: URLRequest) -> any Span {

--- a/Sources/Honeycomb/Networking/NetworkInstrumentation.swift
+++ b/Sources/Honeycomb/Networking/NetworkInstrumentation.swift
@@ -3,7 +3,7 @@ import OpenTelemetryApi
 import SwiftUI
 import UIKit
 
-private let urlSessionInstrumentationName = "io.honeycomb.instrumentation.urlsession"
+private let urlSessionInstrumentationName = "io.honeycomb.urlsession"
 
 /// Creates a span with attributes for the given http request.
 internal func createSpan(from request: URLRequest) -> any Span {

--- a/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
@@ -3,7 +3,7 @@
     import OpenTelemetryApi
     import UIKit
 
-    internal let honeycombUIKitInstrumentationName = "io.honeycomb.instrumentation.uikit"
+    internal let honeycombUIKitInstrumentationName = "io.honeycomb.uikit"
 
     internal func getUIKitViewTracer() -> Tracer {
         return OpenTelemetry.instance.tracerProvider.get(

--- a/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
@@ -3,7 +3,7 @@
     import OpenTelemetryApi
     import UIKit
 
-    internal let honeycombUIKitInstrumentationName = "@honeycombio/instrumentation-uikit"
+    internal let honeycombUIKitInstrumentationName = "io.honeycomb.instrumentation.uikit"
 
     internal func getUIKitViewTracer() -> Tracer {
         return OpenTelemetry.instance.tracerProvider.get(

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -3,7 +3,7 @@
 load test_helpers/utilities
 
 CONTAINER_NAME="ios-test"
-SMOKE_TEST_SCOPE="@honeycombio/smoke-test"
+SMOKE_TEST_SCOPE="io.honeycomb.smoke-test"
 
 setup_file() {
   echo "# 🚧 preparing test" >&3
@@ -37,7 +37,7 @@ teardown_file() {
 #   $1 - attribute key
 #   $2 - attribute type
 mk_attr() {
-  scope="@honeycombio/instrumentation-metric-kit"
+  scope="io.honeycomb.instrumentation.metric-kit"
   span="MXMetricPayload"
   attribute_for_span_key $scope $span $1 $2
 }
@@ -100,7 +100,7 @@ mk_attr() {
 }
 
 @test "MXSignpostMetric data is present" {
-  scope="@honeycombio/instrumentation-metric-kit"
+  scope="io.honeycomb.instrumentation.metric-kit"
   span="MXSignpostMetric"
 
   result=$(attributes_from_span_named $scope $span | jq .key | sort | uniq)
@@ -124,7 +124,7 @@ mk_attr() {
 #   $1 - attribute key
 #   $2 - attribute type
 mk_diag_attr() {
-  scope="@honeycombio/instrumentation-metric-kit"
+  scope="io.honeycomb.instrumentation.metric-kit"
   attribute_for_log_key $scope $1 $2
 }
 
@@ -145,7 +145,7 @@ mk_diag_attr() {
 }
 
 @test "URLSession all requests are present" {
-  result=$(attribute_for_span_key "@honeycombio/instrumentation-urlsession" GET request-id string | sort)
+  result=$(attribute_for_span_key "io.honeycomb.instrumentation.urlsession" GET request-id string | sort)
   assert_equal "$result" '"data-async-obj"
 "data-async-obj-session"
 "data-async-url"
@@ -179,21 +179,21 @@ mk_diag_attr() {
 }
 
 @test "URLSession attributes are correct" {
-  result=$(attribute_for_span_key "@honeycombio/instrumentation-urlsession" GET http.response.status_code int | uniq -c)
+  result=$(attribute_for_span_key "io.honeycomb.instrumentation.urlsession" GET http.response.status_code int | uniq -c)
   assert_equal "$result" '  30 "200"'
 
-  result=$(attribute_for_span_key "@honeycombio/instrumentation-urlsession" GET server.address string | uniq -c)
+  result=$(attribute_for_span_key "io.honeycomb.instrumentation.urlsession" GET server.address string | uniq -c)
   assert_equal "$result" '  30 "localhost"'
 }
 
 @test "Render Instrumentation attributes are correct" {
   # we got the spans we expect
-  result=$(span_names_for "@honeycombio/instrumentation-view" | sort | uniq -c)
+  result=$(span_names_for "io.honeycomb.instrumentation.view" | sort | uniq -c)
   assert_equal "$result" '   7 "View Body"
    7 "View Render"'
    
   # the View Render spans are tracking the views we expect
-  total_duration=$(attribute_for_span_key "@honeycombio/instrumentation-view" "View Render" "view.name" string | sort)
+  total_duration=$(attribute_for_span_key "io.honeycomb.instrumentation.view" "View Render" "view.name" string | sort)
   assert_equal "$total_duration" '"expensive text 1"
 "expensive text 2"
 "expensive text 3"
@@ -204,25 +204,25 @@ mk_diag_attr() {
 }
 
 @test "UIViewController attributes are correct" {
-    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
+    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidAppear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UIKit Menu"'
 
-    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidDisappear \
+    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidDisappear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UIKit Menu"'
     
-        result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
+        result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidAppear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UI KIT SCREEN OVERRIDE"'
 
-    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidDisappear \
+    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidDisappear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq)
@@ -230,7 +230,7 @@ mk_diag_attr() {
 }
 
 @test "UITabView attributes are correct" {
-    result=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" viewDidAppear \
+    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidAppear \
         | jq "select (.key == \"view.class\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController\").value.stringValue" \
         | uniq)
@@ -238,36 +238,36 @@ mk_diag_attr() {
 }
 
 @test "UIKit touch events are captured" {
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Began" "Simple Button")
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Began" "accessibleButton")
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Began" "switch")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Began" "Simple Button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Began" "accessibleButton")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Began" "switch")
 
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Ended" "Simple Button")
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "Touch Ended" "accessibleButton")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Ended" "Simple Button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Ended" "accessibleButton")
     # UISwitch does not support Touch Ended events at this time. Apple sets the view to null.
     
-    screen_name_attr=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" "Touch Began" \
+    screen_name_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_name_attr" '"UI KIT SCREEN OVERRIDE"'
     
-    screen_path_attr=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" "Touch Began" \
+    screen_path_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
         | jq "select (.key == \"screen.path\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_path_attr" '"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UI KIT SCREEN OVERRIDE"'
     
-    screen_name_attr=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" "Touch Began" \
+    screen_name_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_name_attr" '"UIKit Menu"'
     
-    screen_path_attr=$(attributes_from_span_named "@honeycombio/instrumentation-uikit" "Touch Began" \
+    screen_path_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
         | jq "select (.key == \"screen.path\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UIKit Menu\").value.stringValue" \
         | uniq
@@ -276,12 +276,12 @@ mk_diag_attr() {
 }
 
 @test "UIKit click events are captured" {
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "click" "Simple Button")
-    assert_not_empty $(spans_on_view_named "@honeycombio/instrumentation-uikit" "click" "accessibleButton")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "click" "Simple Button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "click" "accessibleButton")
 }
 
 @test "UIKit touch events have all attributes" {
-    span=$(spans_on_view_named "@honeycombio/instrumentation-uikit" "click" "accessibleButton")
+    span=$(spans_on_view_named "io.honeycomb.instrumentation.uikit" "click" "accessibleButton")
 
     name=$(echo "$span" | jq '.attributes[] | select(.key == "view.name").value.stringValue')
     assert_equal "$name" '"accessibleButton"'
@@ -300,7 +300,7 @@ mk_diag_attr() {
 }
 
 @test "Navigation spans are correct" {
-    result=$(attribute_for_span_key "@honeycombio/instrumentation-navigation" Navigation "screen.name" string \
+    result=$(attribute_for_span_key "io.honeycomb.instrumentation.navigation" Navigation "screen.name" string \
         | sort \
         | uniq -c)
     root_count=$(echo "$result" | grep "\[\]")
@@ -311,7 +311,7 @@ mk_diag_attr() {
 }
 
 @test "Navigation attributes are correct" {
-    result=$(attribute_for_span_key "@honeycombio/instrumentation-view" "View Render" "screen.name" string | uniq)
+    result=$(attribute_for_span_key "io.honeycomb.instrumentation.view" "View Render" "screen.name" string | uniq)
     assert_equal "$result" '"View Instrumentation"'
 }
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -37,7 +37,7 @@ teardown_file() {
 #   $1 - attribute key
 #   $2 - attribute type
 mk_attr() {
-  scope="io.honeycomb.metric-kit"
+  scope="io.honeycomb.metrickit"
   span="MXMetricPayload"
   attribute_for_span_key $scope $span $1 $2
 }
@@ -100,7 +100,7 @@ mk_attr() {
 }
 
 @test "MXSignpostMetric data is present" {
-  scope="io.honeycomb.metric-kit"
+  scope="io.honeycomb.metrickit"
   span="MXSignpostMetric"
 
   result=$(attributes_from_span_named $scope $span | jq .key | sort | uniq)
@@ -124,7 +124,7 @@ mk_attr() {
 #   $1 - attribute key
 #   $2 - attribute type
 mk_diag_attr() {
-  scope="io.honeycomb.metric-kit"
+  scope="io.honeycomb.metrickit"
   attribute_for_log_key $scope $1 $2
 }
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -37,7 +37,7 @@ teardown_file() {
 #   $1 - attribute key
 #   $2 - attribute type
 mk_attr() {
-  scope="io.honeycomb.instrumentation.metric-kit"
+  scope="io.honeycomb.metric-kit"
   span="MXMetricPayload"
   attribute_for_span_key $scope $span $1 $2
 }
@@ -100,7 +100,7 @@ mk_attr() {
 }
 
 @test "MXSignpostMetric data is present" {
-  scope="io.honeycomb.instrumentation.metric-kit"
+  scope="io.honeycomb.metric-kit"
   span="MXSignpostMetric"
 
   result=$(attributes_from_span_named $scope $span | jq .key | sort | uniq)
@@ -124,7 +124,7 @@ mk_attr() {
 #   $1 - attribute key
 #   $2 - attribute type
 mk_diag_attr() {
-  scope="io.honeycomb.instrumentation.metric-kit"
+  scope="io.honeycomb.metric-kit"
   attribute_for_log_key $scope $1 $2
 }
 
@@ -145,7 +145,7 @@ mk_diag_attr() {
 }
 
 @test "URLSession all requests are present" {
-  result=$(attribute_for_span_key "io.honeycomb.instrumentation.urlsession" GET request-id string | sort)
+  result=$(attribute_for_span_key "io.honeycomb.urlsession" GET request-id string | sort)
   assert_equal "$result" '"data-async-obj"
 "data-async-obj-session"
 "data-async-url"
@@ -179,21 +179,21 @@ mk_diag_attr() {
 }
 
 @test "URLSession attributes are correct" {
-  result=$(attribute_for_span_key "io.honeycomb.instrumentation.urlsession" GET http.response.status_code int | uniq -c)
+  result=$(attribute_for_span_key "io.honeycomb.urlsession" GET http.response.status_code int | uniq -c)
   assert_equal "$result" '  30 "200"'
 
-  result=$(attribute_for_span_key "io.honeycomb.instrumentation.urlsession" GET server.address string | uniq -c)
+  result=$(attribute_for_span_key "io.honeycomb.urlsession" GET server.address string | uniq -c)
   assert_equal "$result" '  30 "localhost"'
 }
 
 @test "Render Instrumentation attributes are correct" {
   # we got the spans we expect
-  result=$(span_names_for "io.honeycomb.instrumentation.view" | sort | uniq -c)
+  result=$(span_names_for "io.honeycomb.view" | sort | uniq -c)
   assert_equal "$result" '   7 "View Body"
    7 "View Render"'
    
   # the View Render spans are tracking the views we expect
-  total_duration=$(attribute_for_span_key "io.honeycomb.instrumentation.view" "View Render" "view.name" string | sort)
+  total_duration=$(attribute_for_span_key "io.honeycomb.view" "View Render" "view.name" string | sort)
   assert_equal "$total_duration" '"expensive text 1"
 "expensive text 2"
 "expensive text 3"
@@ -204,25 +204,25 @@ mk_diag_attr() {
 }
 
 @test "UIViewController attributes are correct" {
-    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidAppear \
+    result=$(attributes_from_span_named "io.honeycomb.uikit" viewDidAppear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UIKit Menu"'
 
-    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidDisappear \
+    result=$(attributes_from_span_named "io.honeycomb.uikit" viewDidDisappear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UIKit Menu"'
     
-        result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidAppear \
+        result=$(attributes_from_span_named "io.honeycomb.uikit" viewDidAppear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UI KIT SCREEN OVERRIDE"'
 
-    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidDisappear \
+    result=$(attributes_from_span_named "io.honeycomb.uikit" viewDidDisappear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq)
@@ -230,7 +230,7 @@ mk_diag_attr() {
 }
 
 @test "UITabView attributes are correct" {
-    result=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" viewDidAppear \
+    result=$(attributes_from_span_named "io.honeycomb.uikit" viewDidAppear \
         | jq "select (.key == \"view.class\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController\").value.stringValue" \
         | uniq)
@@ -238,36 +238,36 @@ mk_diag_attr() {
 }
 
 @test "UIKit touch events are captured" {
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Began" "Simple Button")
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Began" "accessibleButton")
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Began" "switch")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "Touch Began" "Simple Button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "Touch Began" "accessibleButton")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "Touch Began" "switch")
 
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Ended" "Simple Button")
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "Touch Ended" "accessibleButton")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "Touch Ended" "Simple Button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "Touch Ended" "accessibleButton")
     # UISwitch does not support Touch Ended events at this time. Apple sets the view to null.
     
-    screen_name_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
+    screen_name_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_name_attr" '"UI KIT SCREEN OVERRIDE"'
     
-    screen_path_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
+    screen_path_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.path\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_path_attr" '"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UI KIT SCREEN OVERRIDE"'
     
-    screen_name_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
+    screen_name_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_name_attr" '"UIKit Menu"'
     
-    screen_path_attr=$(attributes_from_span_named "io.honeycomb.instrumentation.uikit" "Touch Began" \
+    screen_path_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.path\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UIKit Menu\").value.stringValue" \
         | uniq
@@ -276,12 +276,12 @@ mk_diag_attr() {
 }
 
 @test "UIKit click events are captured" {
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "click" "Simple Button")
-    assert_not_empty $(spans_on_view_named "io.honeycomb.instrumentation.uikit" "click" "accessibleButton")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "click" "Simple Button")
+    assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "click" "accessibleButton")
 }
 
 @test "UIKit touch events have all attributes" {
-    span=$(spans_on_view_named "io.honeycomb.instrumentation.uikit" "click" "accessibleButton")
+    span=$(spans_on_view_named "io.honeycomb.uikit" "click" "accessibleButton")
 
     name=$(echo "$span" | jq '.attributes[] | select(.key == "view.name").value.stringValue')
     assert_equal "$name" '"accessibleButton"'
@@ -300,7 +300,7 @@ mk_diag_attr() {
 }
 
 @test "Navigation spans are correct" {
-    result=$(attribute_for_span_key "io.honeycomb.instrumentation.navigation" Navigation "screen.name" string \
+    result=$(attribute_for_span_key "io.honeycomb.navigation" Navigation "screen.name" string \
         | sort \
         | uniq -c)
     root_count=$(echo "$result" | grep "\[\]")
@@ -311,7 +311,7 @@ mk_diag_attr() {
 }
 
 @test "Navigation attributes are correct" {
-    result=$(attribute_for_span_key "io.honeycomb.instrumentation.view" "View Render" "screen.name" string | uniq)
+    result=$(attribute_for_span_key "io.honeycomb.view" "View Render" "screen.name" string | uniq)
     assert_equal "$result" '"View Instrumentation"'
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
`@honeycombio/` naming is a web convention. This PR switches it up to reverse url notation.

## Short description of the changes
- Changed instrumentation names. I went with `io.honeycomb.instrumentation.*` notation, where the last chunk is a `kebab-case` name for the instrumentation.
- Changed smoke tests to match

## How to verify that this has the expected result
Smoke tests still pass.

---

- [x] Changelog is updated
