### PR TITLE
docs: Document available config options in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,37 @@ To manually send a span:
     span.end()
 ```
 
+## Configuration Options
+
+| Option               | Type                           | Required? | Description                                                                                          |
+|----------------------|--------------------------------|-----------|------------------------------------------------------------------------------------------------------|
+| `tracesApiKey`       | String                         | No        | Dedicated API Key to use when sending traces.                                                        |
+| `metricsApiKey`      | String                         | No        | Dedicated API Key to use when sending metrics.                                                       |
+| `logsApiKey`         | String                         | No        | Dedicated API Key to use when sending logs.                                                          |
+| `dataset`            | String                         | No        | Name of Honeycomb dataset to send traces to. Required if sending to a classic Honeycomb environment. |
+| `metricsDataset`     | String                         | No        | Name of Honeycomb dataset to send metrics to, instead of `dataset`.                                  |
+| `tracesEndpoint`     | String                         | No        | API endpoint to send traces to.                                                                      |
+| `metricsEndpoint`    | String                         | No        | API endpoint to send metrics to.                                                                     |
+| `logsEndpoint`       | String                         | No        | API endpoint to send trace to.                                                                       |
+| `sampleRate`         | Int                            | No        | Sample rate to apply (ie. a value of `40` means 1 in 40 traces will be exported).                    |
+| `debug`              | Boolean                        | No        | Enable debug logging.                                                                                |
+| `serviceName`        | String?                        | No        | Name of Honeycomb service to send data to.                                                           |
+| `resourceAttributes` | Map<String, String>            | No        | Attributes to attach to outgoing resources.                                                          |
+| `headers`            | Map<String, String>            | No        | Headers to include on exported data.                                                                 |
+| `tracesHeaders`      | Map<String, String>            | No        | Headers to add to exported trace data.                                                               |
+| `metricsHeaders`     | Map<String, String>            | No        | Headers to add to exported metrics data.                                                             |
+| `logsHeaders`        | Map<String, String>            | No        | Headers to add to exported logs data.                                                                |
+| `timeout`            | Duration                       | No        | Timeout used by exporter when sending data.                                                          |
+| `tracesTimeout`      | Duration                       | No        | Timeout used by traces exporter. Overrides `timeout` for trace data.                                 |
+| `metricsTimeout`     | Duration                       | No        | Timeout used by metrics exporter. Overrides `timeout` for metrics data.                              |
+| `logsTimeout`        | Duration                       | No        | Timeout used by logs exporter. Overrides `timeout` for logs data.                                    |
+| `protocol`           | HoneycombOptions.OtlpProtocol  | No        | Protocol to use when sending data.                                                                   |
+| `tracesProtocol`     | HoneycombOptions.OtlpProtocol  | No        | Overrides `protocol` for trace data.                                                                 |
+| `metricsProtocol`    | HoneycombOptions.OtlpProtocol  | No        | Overrides `protocol` for metrics data.                                                               |
+| `logsProtocol`       | HoneycombOptions.OtlpProtocol  | No        | Overrides `protocol` for logs data.                                                                  |
+| `spanProcessor`      | OpenTelemetryApi.SpanProcessor | No        | Additional span processor to use.                                                                    |
+| `sessionTimeout`     | TimeInterval                   | No        | Maximum length of time for a single user session. Used to generate `session.id` span attribute.      |
+
 ## Auto-instrumentation
 
 The following auto-instrumentation libraries are automatically included:

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -27,10 +27,6 @@ private let otelServiceNameKey = "OTEL_SERVICE_NAME"
 private let otelServiceNameDefault = "unknown_service"
 private let otelResourceAttributesKey = "OTEL_RESOURCE_ATTRIBUTES"
 
-private let otelTracesSamplerKey = "OTEL_TRACES_SAMPLER"
-private let otelTracesSamplerDefault = "parentbased_always_on"
-private let otelTracesSamplerArgKey = "OTEL_TRACES_SAMPLER_ARG"
-
 private let otelPropagatorsKey = "OTEL_PROPAGATORS"
 private let otelPropagatorsDefault = "tracecontext,baggage"
 
@@ -172,9 +168,6 @@ public struct HoneycombOptions {
 
     let serviceName: String
     let resourceAttributes: [String: String]
-    let tracesSampler: String
-    let tracesSamplerArg: String?
-    let propagators: String
 
     let tracesHeaders: [String: String]
     let metricsHeaders: [String: String]
@@ -211,9 +204,6 @@ public struct HoneycombOptions {
 
         private var serviceName: String? = nil
         private var resourceAttributes: [String: String] = [:]
-        private var tracesSampler: String = otelTracesSamplerDefault
-        private var tracesSamplerArg: String? = nil
-        private var propagators: String = otelPropagatorsDefault
 
         private var headers: [String: String] = [:]
         private var tracesHeaders: [String: String] = [:]
@@ -274,9 +264,6 @@ public struct HoneycombOptions {
             debug = try source.getBool(debugKey) ?? debug
             serviceName = try source.getString(otelServiceNameKey) ?? serviceName
             resourceAttributes = try source.getKeyValueList(otelResourceAttributesKey)
-            tracesSampler = try source.getString(otelTracesSamplerKey) ?? tracesSampler
-            tracesSamplerArg = try source.getString(otelTracesSamplerArgKey)
-            propagators = try source.getString(otelPropagatorsKey) ?? propagators
             headers = try source.getKeyValueList(otlpHeadersKey)
             tracesHeaders = try source.getKeyValueList(otlpTracesHeadersKey)
             metricsHeaders = try source.getKeyValueList(otlpMetricsHeadersKey)
@@ -358,21 +345,6 @@ public struct HoneycombOptions {
 
         public func setResourceAttributes(_ resources: [String: String]) -> Builder {
             resourceAttributes = resources
-            return self
-        }
-
-        public func setTracesSampler(_ sampler: String) -> Builder {
-            tracesSampler = sampler
-            return self
-        }
-
-        public func setTracesSamplerArg(_ arg: String?) -> Builder {
-            tracesSamplerArg = arg
-            return self
-        }
-
-        public func setPropagators(_ propagators: String) -> Builder {
-            self.propagators = propagators
             return self
         }
 
@@ -538,9 +510,6 @@ public struct HoneycombOptions {
                 debug: debug,
                 serviceName: serviceName,
                 resourceAttributes: resourceAttributes,
-                tracesSampler: tracesSampler,
-                tracesSamplerArg: tracesSamplerArg,
-                propagators: propagators,
                 tracesHeaders: tracesHeaders,
                 metricsHeaders: metricsHeaders,
                 logsHeaders: logsHeaders,

--- a/Tests/Honeycomb/HoneycombOptionsTests.swift
+++ b/Tests/Honeycomb/HoneycombOptionsTests.swift
@@ -38,10 +38,6 @@ final class HoneycombOptionsTests: XCTestCase {
         ]
         XCTAssertEqual(expectedResources, options.resourceAttributes)
 
-        XCTAssertEqual("parentbased_always_on", options.tracesSampler)
-        XCTAssertNil(options.tracesSamplerArg)
-        XCTAssertEqual("tracecontext,baggage", options.propagators)
-
         XCTAssertEqual("https://api.honeycomb.io:443/v1/traces", options.tracesEndpoint)
         XCTAssertEqual("https://api.honeycomb.io:443/v1/metrics", options.metricsEndpoint)
         XCTAssertEqual("https://api.honeycomb.io:443/v1/logs", options.logsEndpoint)
@@ -86,10 +82,6 @@ final class HoneycombOptionsTests: XCTestCase {
             "honeycomb.distro.runtime_version": runtimeVersion,
         ]
         XCTAssertEqual(expectedResources, options.resourceAttributes)
-
-        XCTAssertEqual("parentbased_always_on", options.tracesSampler)
-        XCTAssertNil(options.tracesSamplerArg)
-        XCTAssertEqual("tracecontext,baggage", options.propagators)
 
         XCTAssertEqual("https://api.honeycomb.io:443/v1/traces", options.tracesEndpoint)
         XCTAssertEqual("https://api.honeycomb.io:443/v1/metrics", options.metricsEndpoint)
@@ -137,10 +129,6 @@ final class HoneycombOptionsTests: XCTestCase {
         ]
         XCTAssertEqual(expectedResources, options.resourceAttributes)
 
-        XCTAssertEqual("sampler", options.tracesSampler)
-        XCTAssertEqual("arg", options.tracesSamplerArg)
-        XCTAssertEqual("propagators", options.propagators)
-
         XCTAssertEqual("http://example.com:1234/v1/traces", options.tracesEndpoint)
         XCTAssertEqual("http://example.com:1234/v1/metrics", options.metricsEndpoint)
         XCTAssertEqual("http://example.com:1234/v1/logs", options.logsEndpoint)
@@ -171,9 +159,6 @@ final class HoneycombOptionsTests: XCTestCase {
             .setDebug(true)
             .setServiceName("service")
             .setResourceAttributes(["resource": "aaa"])
-            .setTracesSampler("sampler")
-            .setTracesSamplerArg("arg")
-            .setPropagators("propagators")
             .setTimeout(30)
             .setHeaders(["header": "hhh"])
             .setProtocol(OTLPProtocol.httpJSON)
@@ -187,10 +172,6 @@ final class HoneycombOptionsTests: XCTestCase {
             "honeycomb.distro.runtime_version": runtimeVersion,
         ]
         XCTAssertEqual(expectedResources, options.resourceAttributes)
-
-        XCTAssertEqual("sampler", options.tracesSampler)
-        XCTAssertEqual("arg", options.tracesSamplerArg)
-        XCTAssertEqual("propagators", options.propagators)
 
         XCTAssertEqual("http://api.example.com:1234/v1/traces", options.tracesEndpoint)
         XCTAssertEqual("http://api.example.com:1234/v1/metrics", options.metricsEndpoint)
@@ -257,10 +238,6 @@ final class HoneycombOptionsTests: XCTestCase {
         ]
         XCTAssertEqual(expectedResources, options.resourceAttributes)
 
-        XCTAssertEqual("sampler", options.tracesSampler)
-        XCTAssertEqual("arg", options.tracesSamplerArg)
-        XCTAssertEqual("propagators", options.propagators)
-
         XCTAssertEqual("http://traces.example.com:1234", options.tracesEndpoint)
         XCTAssertEqual("http://metrics.example.com:1234", options.metricsEndpoint)
         XCTAssertEqual("http://logs.example.com:1234", options.logsEndpoint)
@@ -319,9 +296,6 @@ final class HoneycombOptionsTests: XCTestCase {
             .setDebug(true)
             .setServiceName("service")
             .setResourceAttributes(["resource": "aaa"])
-            .setTracesSampler("sampler")
-            .setTracesSamplerArg("arg")
-            .setPropagators("propagators")
             .setTracesTimeout(40)
             .setMetricsTimeout(50)
             .setLogsTimeout(60)
@@ -341,10 +315,6 @@ final class HoneycombOptionsTests: XCTestCase {
             "honeycomb.distro.runtime_version": runtimeVersion,
         ]
         XCTAssertEqual(expectedResources, options.resourceAttributes)
-
-        XCTAssertEqual("sampler", options.tracesSampler)
-        XCTAssertEqual("arg", options.tracesSamplerArg)
-        XCTAssertEqual("propagators", options.propagators)
 
         XCTAssertEqual("http://traces.example.com:1234", options.tracesEndpoint)
         XCTAssertEqual("http://metrics.example.com:1234", options.metricsEndpoint)


### PR DESCRIPTION
## Which problem is this PR solving?
Users don't know what config options are available.

## Short description of the changes
Added table with available config options to the README. 
Removed unused config options `tracesSampler`, `tracesSamplerArg`, and `propagators`.

## How to verify that this has the expected result
- [x] tests pass
- [x] readme descriptions make sense

---

- ~[ ] Changelog is updated~ N/A
