### PR TITLE
feat: add api to enable or disable instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ### New Features
 
+* Package is now available on Cocoapods.
 * Add new options to enable/disable built-in auto-instrumentation.
 
 ## 0.0.5-alpha
 
 ### New Features
 
-* Package is now available on Cocoapods.
 * Add a `setSpanProcessor()` function to `HoneycombOptions` builder to allow clients to supply custom span processors.
 
 ## 0.0.4-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Honeycomb OpenTelemetry SDK Changelog
 ### New Features
 
 * Package is now available on Cocoapods.
+* Adds new options to enable/disable built-in auto-instrumentation.
 
 ## 0.0.4-alpha
 

--- a/Examples/SmokeTest/SmokeTest/SmokeTestApp.swift
+++ b/Examples/SmokeTest/SmokeTest/SmokeTestApp.swift
@@ -12,6 +12,7 @@ struct SmokeTestApp: App {
                 .setDebug(true)
                 .setSessionTimeout(10)
                 .setSpanProcessor(SampleSpanProcessor())
+                .setTouchInstrumentationEnabled(true)
                 .build()
             try Honeycomb.configure(options: options)
         } catch {

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ To manually send a span:
 
 | Option               | Type                           | Required? | Description                                                                                          |
 |----------------------|--------------------------------|-----------|------------------------------------------------------------------------------------------------------|
-| `tracesApiKey`       | String                         | No        | Dedicated API Key to use when sending traces.                                                        |
-| `metricsApiKey`      | String                         | No        | Dedicated API Key to use when sending metrics.                                                       |
-| `logsApiKey`         | String                         | No        | Dedicated API Key to use when sending logs.                                                          |
+| `tracesAPIKey`       | String                         | No        | Dedicated API Key to use when sending traces.                                                        |
+| `metricsAPIKey`      | String                         | No        | Dedicated API Key to use when sending metrics.                                                       |
+| `logsAPIKey`         | String                         | No        | Dedicated API Key to use when sending logs.                                                          |
 | `dataset`            | String                         | No        | Name of Honeycomb dataset to send traces to. Required if sending to a classic Honeycomb environment. |
 | `metricsDataset`     | String                         | No        | Name of Honeycomb dataset to send metrics to, instead of `dataset`.                                  |
 | `tracesEndpoint`     | String                         | No        | API endpoint to send traces to.                                                                      |
@@ -101,6 +101,11 @@ To manually send a span:
 | `logsProtocol`       | HoneycombOptions.OtlpProtocol  | No        | Overrides `protocol` for logs data.                                                                  |
 | `spanProcessor`      | OpenTelemetryApi.SpanProcessor | No        | Additional span processor to use.                                                                    |
 | `sessionTimeout`     | TimeInterval                   | No        | Maximum length of time for a single user session. Used to generate `session.id` span attribute.      |
+| `metricKitInstrumentationEnabled`          | Bool     | No        | Whether to enable MetricKit instrumentation. (default: true)                                         |
+| `urlSessionInstrumentationEnabled`         | Bool     | No        | Whether to enable URLSession instrumentation. (default: true)                                        |
+| `uiKitInstrumentationEnabled`              | Bool     | No        | Whether to enable UIKit view instrumentation. (default: true)                                        |
+| `touchInstrumentationEnabled`              | Bool     | No        | Whether to enable UIKit touch instrumentation (default: false)                                       |
+| `unhandledExceptionInstrumentationEnabled` | Bool     | No        | Whether to enable unhandle exception instrumentation. (default: true)                                |
 
 ## Auto-instrumentation
 

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -197,12 +197,20 @@ public class Honeycomb {
         OpenTelemetry.registerMeterProvider(meterProvider: meterProvider)
         OpenTelemetry.registerLoggerProvider(loggerProvider: loggerProvider)
 
-        installNetworkInstrumentation(options: options)
-        installUINavigationInstrumentation()
-        installWindowInstrumentation()
+        if options.urlSessionInstrumentationEnabled {
+            installNetworkInstrumentation(options: options)
+        }
+        if options.uiKitInstrumentationEnabled {
+            installUINavigationInstrumentation()
+        }
+        if options.touchInstrumentationEnabled {
+            installWindowInstrumentation()
+        }
 
         if #available(iOS 13.0, macOS 12.0, *) {
-            MXMetricManager.shared.add(self.metricKitSubscriber)
+            if options.metricKitInstrumentationEnabled {
+                MXMetricManager.shared.add(self.metricKitSubscriber)
+            }
         }
     }
 

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -192,6 +192,12 @@ public struct HoneycombOptions {
 
     let sessionTimeout: TimeInterval
 
+    let metricKitInstrumentationEnabled: Bool
+    let urlSessionInstrumentationEnabled: Bool
+    let uiKitInstrumentationEnabled: Bool
+    let touchInstrumentationEnabled: Bool
+    let unhandledExceptionInstrumentationEnabled: Bool
+
     public class Builder {
         private var apiKey: String? = nil
         private var tracesApiKey: String? = nil
@@ -233,6 +239,12 @@ public struct HoneycombOptions {
         private var spanProcessor: SpanProcessor? = nil
 
         private var sessionTimeout: TimeInterval = TimeInterval(60 * 60 * 4)  // 4 hours
+
+        private var metricKitInstrumentationEnabled: Bool = true
+        private var urlSessionInstrumentationEnabled: Bool = true
+        private var uiKitInstrumentationEnabled: Bool = true
+        private var touchInstrumentationEnabled: Bool = false
+        private var unhandledExceptionInstrumentationEnabled: Bool = true
 
         /// Creates a builder with default options.
         public init() {}
@@ -446,6 +458,27 @@ public struct HoneycombOptions {
             return self
         }
 
+        public func setMetricKitInstrumentationEnabled(_ enabled: Bool) -> Builder {
+            metricKitInstrumentationEnabled = enabled
+            return self
+        }
+        public func setURLSessionInstrumentationEnabled(_ enabled: Bool) -> Builder {
+            urlSessionInstrumentationEnabled = enabled
+            return self
+        }
+        public func setUIKitInstrumentationEnabled(_ enabled: Bool) -> Builder {
+            uiKitInstrumentationEnabled = enabled
+            return self
+        }
+        public func setTouchInstrumentationEnabled(_ enabled: Bool) -> Builder {
+            touchInstrumentationEnabled = enabled
+            return self
+        }
+        public func setUnhandledExceptionInstrumentationEnabled(_ enabled: Bool) -> Builder {
+            unhandledExceptionInstrumentationEnabled = enabled
+            return self
+        }
+
         public func build() throws -> HoneycombOptions {
             // If any API key isn't set, consider it a fatal error.
             let defaultApiKey: () throws -> String = {
@@ -551,7 +584,12 @@ public struct HoneycombOptions {
                 metricsProtocol: metricsProtocol ?? `protocol`,
                 logsProtocol: logsProtocol ?? `protocol`,
                 spanProcessor: spanProcessor,
-                sessionTimeout: sessionTimeout
+                sessionTimeout: sessionTimeout,
+                metricKitInstrumentationEnabled: metricKitInstrumentationEnabled,
+                urlSessionInstrumentationEnabled: urlSessionInstrumentationEnabled,
+                uiKitInstrumentationEnabled: uiKitInstrumentationEnabled,
+                touchInstrumentationEnabled: touchInstrumentationEnabled,
+                unhandledExceptionInstrumentationEnabled: unhandledExceptionInstrumentationEnabled
             )
         }
 

--- a/Tests/Honeycomb/HoneycombOptionsTests.swift
+++ b/Tests/Honeycomb/HoneycombOptionsTests.swift
@@ -61,6 +61,12 @@ final class HoneycombOptionsTests: XCTestCase {
         XCTAssertEqual(OTLPProtocol.httpProtobuf, options.tracesProtocol)
         XCTAssertEqual(OTLPProtocol.httpProtobuf, options.metricsProtocol)
         XCTAssertEqual(OTLPProtocol.httpProtobuf, options.logsProtocol)
+
+        XCTAssertTrue(options.metricKitInstrumentationEnabled)
+        XCTAssertTrue(options.urlSessionInstrumentationEnabled)
+        XCTAssertTrue(options.uiKitInstrumentationEnabled)
+        XCTAssertFalse(options.touchInstrumentationEnabled)
+        XCTAssertTrue(options.unhandledExceptionInstrumentationEnabled)
     }
 
     func testOptionsWithEmptyStrings() throws {
@@ -331,6 +337,11 @@ final class HoneycombOptionsTests: XCTestCase {
             .setTracesProtocol(OTLPProtocol.grpc)
             .setMetricsProtocol(OTLPProtocol.grpc)
             .setLogsProtocol(OTLPProtocol.grpc)
+            .setMetricKitInstrumentationEnabled(false)
+            .setURLSessionInstrumentationEnabled(false)
+            .setUIKitInstrumentationEnabled(false)
+            .setTouchInstrumentationEnabled(true)
+            .setUnhandledExceptionInstrumentationEnabled(false)
             .build()
 
         XCTAssertEqual("service", options.serviceName)
@@ -388,6 +399,12 @@ final class HoneycombOptionsTests: XCTestCase {
 
         XCTAssertTrue(options.debug)
         XCTAssertEqual(42, options.sampleRate)
+
+        XCTAssertFalse(options.metricKitInstrumentationEnabled)
+        XCTAssertFalse(options.urlSessionInstrumentationEnabled)
+        XCTAssertFalse(options.uiKitInstrumentationEnabled)
+        XCTAssertTrue(options.touchInstrumentationEnabled)
+        XCTAssertFalse(options.unhandledExceptionInstrumentationEnabled)
     }
 
     func testDatasetSetWithClassicKey() throws {


### PR DESCRIPTION

## Which problem is this PR solving?

Currently there is no way to choose which auto-instrumentation is enabled or disabled, but some consumers may not want all of them, especially the touch instrumentation, which is pretty noisy.

## Short description of the changes

* Adds options for each of the current auto-instrumentations included in our SDK.
* Changes the touch instrumentation to default to off, since it is so noisy.
* Preëmptively adds an option for the upcoming unhandled exception auto-instrumentation.

## How to verify that this has the expected result

* Adds new unit tests to verify the options get set.
* Updates the smoke tests to enable the touch instrumentation.

---

- [✅] Changelog is updated
