### PR TITLE
fix: make sessions threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,12 @@ Honeycomb OpenTelemetry SDK Changelog
 ### New Features
 
 * Error logging API for manually logging exceptions.
-
-### Fixes
-
-* Update instrumentation names to use reverse url notation (`io.honeycomb.*`) instead of `@honeycombio/instrumentation-*` notation. 
-
-### New Features
-
 * Package is now available on Cocoapods.
 * Add new options to enable/disable built-in auto-instrumentation.
 
 ### Fixes
 
+* Update instrumentation names to use reverse url notation (`io.honeycomb.*`) instead of `@honeycombio/instrumentation-*` notation. 
 * Make session id management threadsafe.
 
 ## 0.0.5-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+### New Features
+
 * Update instrumentation names to use reverse url notation (`io.honeycomb.*`) instead of `@honeycombio/instrumentation-*` notation. 
 * Package is now available on Cocoapods.
+
+### Fixes
+
+* Make session id management threadsafe.
 
 ## 0.0.5-alpha
 

--- a/Sources/Honeycomb/Session/HoneycombSessionManager.swift
+++ b/Sources/Honeycomb/Session/HoneycombSessionManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
+import Synchronization
 
 extension Notification.Name {
     public static let sessionStarted = Notification.Name("io.honeycomb.app.session.started")
@@ -11,6 +12,8 @@ extension Notification.Name {
 }
 
 class HoneycombSessionManager {
+    private var lock: NSLock = NSLock()
+
     private var sessionStorage: SessionStorage
     private var currentSession: HoneycombSession?
     private var debug: Bool
@@ -49,43 +52,45 @@ class HoneycombSessionManager {
     }
 
     var sessionId: String {
-        // If there is no current session make a new one
-        if self.currentSession == nil {
-            let newSession = HoneycombSession(
-                id: sessionIdProvider(),
-                startTimestamp: dateProvider()
-            )
-            if debug {
-                print("HoneycombSessionManager: No active session, creating session.")
-            }
-            onSessionStarted(newSession: newSession, previousSession: nil)
-            self.currentSession = newSession
-        } else if isSessionExpired {
-            // If the session timeout has elapsed, make a new one
-            if debug {
-                print(
-                    "HoneycombSessionManager: Session timeout after \(sessionLifetime) seconds elapsed, creating new session."
+        return lock.withLock {
+            // If there is no current session make a new one
+            if self.currentSession == nil {
+                let newSession = HoneycombSession(
+                    id: sessionIdProvider(),
+                    startTimestamp: dateProvider()
                 )
-            }
-            let previousSession = self.currentSession
-            let newSession = HoneycombSession(
-                id: sessionIdProvider(),
-                startTimestamp: dateProvider()
-            )
+                if debug {
+                    print("HoneycombSessionManager: No active session, creating session.")
+                }
+                onSessionStarted(newSession: newSession, previousSession: nil)
+                self.currentSession = newSession
+            } else if isSessionExpired {
+                // If the session timeout has elapsed, make a new one
+                if debug {
+                    print(
+                        "HoneycombSessionManager: Session timeout after \(sessionLifetime) seconds elapsed, creating new session."
+                    )
+                }
+                let previousSession = self.currentSession
+                let newSession = HoneycombSession(
+                    id: sessionIdProvider(),
+                    startTimestamp: dateProvider()
+                )
 
-            onSessionStarted(newSession: newSession, previousSession: previousSession)
-            if previousSession != nil {
-                onSessionEnded(session: previousSession!)
+                onSessionStarted(newSession: newSession, previousSession: previousSession)
+                if previousSession != nil {
+                    onSessionEnded(session: previousSession!)
+                }
+                self.currentSession = newSession
             }
-            self.currentSession = newSession
-        }
 
-        guard let currentSession = self.currentSession else {
-            return ""
+            guard let currentSession = self.currentSession else {
+                return ""
+            }
+            // Always return the current session's id
+            sessionStorage.save(session: currentSession)
+            return currentSession.id
         }
-        // Always return the current session's id
-        sessionStorage.save(session: currentSession)
-        return currentSession.id
     }
 
     private func onSessionStarted(newSession: HoneycombSession, previousSession: HoneycombSession?)

--- a/Sources/Honeycomb/Session/HoneycombSessionManager.swift
+++ b/Sources/Honeycomb/Session/HoneycombSessionManager.swift
@@ -1,7 +1,6 @@
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
-import Synchronization
 
 extension Notification.Name {
     public static let sessionStarted = Notification.Name("io.honeycomb.app.session.started")


### PR DESCRIPTION
## Which problem is this PR solving?

We've noticed some strange issues with session IDs changing more frequently than they should. One theory is that there is a race condition, since session ID generation wasn't threadsafe. This PR makes it threadsafe.

## How to verify that this has the expected result

Smoke tests sill pass. It's difficult to test that any potential race condition is fixed.

---

- [✅] Changelog is updated
