### PR TITLE
feat: Catch unhandled exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Honeycomb OpenTelemetry SDK Changelog
 * Error logging API for manually logging exceptions.
 * Package is now available on Cocoapods.
 * Add new options to enable/disable built-in auto-instrumentation.
+* Uncaught exception handler to log crashes.
 
 ### Fixes
 

--- a/Examples/SmokeTest/SmokeTest/ContentView.swift
+++ b/Examples/SmokeTest/SmokeTest/ContentView.swift
@@ -65,6 +65,10 @@ private func sendFakeErrorData() {
     sendFakeNSException()
 }
 
+private func crashTheApp() {
+    CatchNSException.crashTheApp()
+}
+
 struct ContentView: View {
     @State private var sessionId: String = "🐝💭"
     @State private var sessionStartTime: String = "🐝🕰️"
@@ -102,6 +106,11 @@ struct ContentView: View {
 
                 Button(action: sendFakeMetrics) {
                     Text("Send fake MetricKit data")
+                }
+                .buttonStyle(.bordered)
+                
+                Button(action: crashTheApp) {
+                    Text("Crash the App")
                 }
                 .buttonStyle(.bordered)
 

--- a/Examples/SmokeTest/SmokeTest/ContentView.swift
+++ b/Examples/SmokeTest/SmokeTest/ContentView.swift
@@ -108,7 +108,7 @@ struct ContentView: View {
                     Text("Send fake MetricKit data")
                 }
                 .buttonStyle(.bordered)
-                
+
                 Button(action: crashTheApp) {
                     Text("Crash the App")
                 }

--- a/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.h
+++ b/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.h
@@ -6,4 +6,5 @@
 
 @interface CatchNSException : NSObject
 + (NSException *)throwAndCatchNSException;
++ (void)crashTheApp;
 @end

--- a/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.m
+++ b/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.m
@@ -15,4 +15,10 @@
     }
 }
 
++ (void)crashTheApp {
+    @throw [NSException exceptionWithName:@"IntentionalCrash"
+                                   reason:@"Pushed the crash button"
+                                 userInfo:nil];
+}
+
 @end

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -34,22 +34,22 @@ private func createKeyValueList(_ dict: [String: String]) -> [(String, String)] 
 // the signal handler closures can be converted into C pointers
 private func initializeSigCrashHandlers() {
     signal(SIGABRT) { _ in
-        handleErrorSignal(error: HoneycombCrashSignal.SIGABRT)
+        handleErrorSignal(error: .sigAbrt)
     }
     signal(SIGILL) { _ in
-        handleErrorSignal(error: HoneycombCrashSignal.SIGILL)
+        handleErrorSignal(error: .sigIll)
     }
     signal(SIGSEGV) { _ in
-        handleErrorSignal(error: HoneycombCrashSignal.SIGSEGV)
+        handleErrorSignal(error: .sigSegv)
     }
     signal(SIGFPE) { _ in
-        handleErrorSignal(error: .SIGFPE)
+        handleErrorSignal(error: .sigFpe)
     }
     signal(SIGBUS) { _ in
-        handleErrorSignal(error: .SIGBUS)
+        handleErrorSignal(error: .sigbus)
     }
     signal(SIGPIPE) { _ in
-        handleErrorSignal(error: .SIGPIPE)
+        handleErrorSignal(error: .sigPipe)
     }
 }
 
@@ -62,12 +62,12 @@ private func handleErrorSignal(error: HoneycombCrashSignal) {
 }
 
 internal enum HoneycombCrashSignal: Error {
-    case SIGABRT
-    case SIGILL
-    case SIGSEGV
-    case SIGFPE
-    case SIGBUS
-    case SIGPIPE
+    case sigAbrt
+    case sigIll
+    case sigSegv
+    case sigFpe
+    case sigbus
+    case sigPipe
 }
 
 public class Honeycomb {

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -212,6 +212,10 @@ public class Honeycomb {
                 MXMetricManager.shared.add(self.metricKitSubscriber)
             }
         }
+        
+        NSSetUncaughtExceptionHandler{ exception in
+            Honeycomb.log(exception: exception, thread: Thread.current)
+        }
     }
 
     private static let errorLoggerInstrumentationName = "io.honeycomb.error"

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -246,7 +246,7 @@ public class Honeycomb {
         if options.touchInstrumentationEnabled {
             installWindowInstrumentation()
         }
-        
+
         initializeUncaughtExceptionHandling()
 
         if #available(iOS 13.0, macOS 12.0, *) {
@@ -255,9 +255,9 @@ public class Honeycomb {
             }
         }
     }
-    
+
     private static func initializeUncaughtExceptionHandling() {
-        NSSetUncaughtExceptionHandler{ exception in
+        NSSetUncaughtExceptionHandler { exception in
             Honeycomb.log(exception: exception, thread: Thread.current)
         }
 

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -207,19 +207,13 @@ public class Honeycomb {
             installWindowInstrumentation()
         }
         if options.unhandledExceptionInstrumentationEnabled {
-            initializeUnhandledExceptionInstrumentation()
+            HoneycombUncaughtExceptionHandler.initializeUnhandledExceptionInstrumentation()
         }
 
         if #available(iOS 13.0, macOS 12.0, *) {
             if options.metricKitInstrumentationEnabled {
                 MXMetricManager.shared.add(self.metricKitSubscriber)
             }
-        }
-    }
-
-    private static func initializeUnhandledExceptionInstrumentation() {
-        NSSetUncaughtExceptionHandler { exception in
-            Honeycomb.log(exception: exception, thread: Thread.current)
         }
     }
 

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -2,13 +2,14 @@ import Foundation
 
 internal class HoneycombUncaughtExceptionHandler {
     private static var initialUncaughtExceptionHandler: ((NSException) -> Void)? = nil
-    
+
     public static func initializeUnhandledExceptionInstrumentation() {
-        HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler = NSGetUncaughtExceptionHandler()
-        
+        HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler =
+            NSGetUncaughtExceptionHandler()
+
         NSSetUncaughtExceptionHandler { exception in
             Honeycomb.log(exception: exception, thread: Thread.current)
-            
+
             if HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler != nil {
                 HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler!(exception)
             }

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -10,8 +10,10 @@ internal class HoneycombUncaughtExceptionHandler {
         NSSetUncaughtExceptionHandler { exception in
             Honeycomb.log(exception: exception, thread: Thread.current)
 
-            if HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler != nil {
-                HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler!(exception)
+            if let initialHanlder = HoneycombUncaughtExceptionHandler
+                .initialUncaughtExceptionHandler
+            {
+                initialHanlder(exception)
             }
         }
     }

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+internal class HoneycombUncaughtExceptionHandler {
+    private static var initialUncaughtExceptionHandler: ((NSException) -> Void)? = nil
+    
+    public static func initializeUnhandledExceptionInstrumentation() {
+        HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler = NSGetUncaughtExceptionHandler()
+        
+        NSSetUncaughtExceptionHandler { exception in
+            Honeycomb.log(exception: exception, thread: Thread.current)
+            
+            if HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler != nil {
+                HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler!(exception)
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Adds unhandled exception reporting and crash reporting to auto instrumentation. 

- Closes #<enter issue here>

## Short description of the changes

UncaughtExceptionHandler and signal handers have been added to allow crash-litics

## How to verify that this has the expected result

- Open the Smoke test application in xcode
- remove the catch statement from the NSException Objc code.
- Run the app and press the "Send fake error data" button.
- A crash should be logged

---

- [x] Changelog is updated
