### PR TITLE
maint: Add a .clang-format and instructions for running it.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+# This format defaults to the OpenTelemetry style, which is based on Chromium,
+# but deviates by keeping braces on the same line and using 4 space indents,
+# to be consistent with other Honeycomb source code, especially Swift.
+
+# See Clang docs: http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Chromium
+
+# Allow double brackets such as std::vector<std::vector<int>>.
+Standard: Cpp11
+
+# Indent 2 spaces at a time.
+IndentWidth: 4
+
+# Keep lines under 100 columns long.
+ColumnLimit: 100
+
+# Indent case labels.
+IndentCaseLabels: true
+
+# Right-align pointers and references
+PointerAlignment: Right
+

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,6 +8,23 @@
 
 Development and unit tests are done within Xcode. However, there is also a smoke-test, which must be run using the included Makefile.
 
+## Formatting
+
+`clang-format` is required in order to auto-format Objective-C code. To install:
+
+```sh
+brew install clang-format
+```
+
+To lint and/or auto-format code, use the Makefile:
+
+```sh
+make lint
+make format
+```
+
+This will format both Swift and Objective-C.
+
 ## Smoke Tests
 
 Smoke tests use Xcode Command Line Tools and Docker using `docker-compose`, exporting telemetry to a local collector.

--- a/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.h
+++ b/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.h
@@ -4,6 +4,6 @@
 
 #import <Foundation/Foundation.h>
 
-@interface CatchNSException: NSObject
+@interface CatchNSException : NSObject
 + (NSException *)throwAndCatchNSException;
 @end

--- a/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.m
+++ b/Examples/SmokeTest/SmokeTest/ErrorHelpers/CatchNSException.m
@@ -3,14 +3,14 @@
 @implementation CatchNSException
 
 + (NSException *)throwAndCatchNSException {
-    NSException * exception = nil;
+    NSException *exception = nil;
     @try {
-        @throw [NSException exceptionWithName:@"TestException" reason:@"Exception Handling reason" userInfo: nil];
-    }
-    @catch(NSException * caughtException) {
+        @throw [NSException exceptionWithName:@"TestException"
+                                       reason:@"Exception Handling reason"
+                                     userInfo:nil];
+    } @catch (NSException *caughtException) {
         exception = caughtException;
-    }
-    @finally {
+    } @finally {
         return exception;
     }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Our Objective-C code has no linter or auto-formatter. We want this to be automatic so that we don't waste time on formatting discussion in code reviews.

## Short description of the changes

* Adds instructions for installing `clang-format`.
* Adds a `.clang-format` config file based on OTel and existing code.
* Extends `make format` to include Objective-C code.
* Auto-formats the existing Objective-C code.

Note that this does _not_ extend _lint_ to cover Objective-C, as that is non-trivial, and we can always decide to add that later.

## How to verify that this has the expected result

It's a purely cosmetic change, so existing smoke-tests should be sufficient.

---

- [N/A] Changelog is updated
