### PR TITLE
feat(docs): documentation manual error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ struct ContentView: View {
 
 In this case, since View B never reports the navigation, if the user navigates to `View A` and then to `View B`, any spans emitted from `View B` will still report `screen.name: "View A"`.
 
-### Manual Exception Logging Handling
+### Manual Error Logging
 
 Any Errors, NSErrors, or NSExceptions may be recorded as Log records using the `log` method. This can be used for logging 
 any caught exceptions in your own code that will not be logged by our crash instrumentation.

--- a/README.md
+++ b/README.md
@@ -303,10 +303,10 @@ catch let error {
 }
 ```
 
-| Argument        | Type                               | Is Required | Description                                                                                             |
-|-----------------|------------------------------------|-------------|---------------------------------------------------------------------------------------------------------|
-| error/exception | Error/NSError/NSException          | true        | The error or exception itself. Depending on the type of error fields will be automatically added        |
-| attributes      | Dictionary<string, AttributeValue> | false       | Additional attributes you would like to log along with the default ones provided.                       |
-| thread          | Thread                             | false       | Thread where the error occurred. Add this to include additional attributes related to the thread        |
-| logger          | Logger                             | false       | Defaults to the Honeycomb error `Logger`. Provide if you want to use a different OpenTelemetry `Logger` |
+| Argument        | Type                               | Is Required | Description                                                                                                          |
+|-----------------|------------------------------------|-------------|---------------------------------------------------------------------------------------------------------             |
+| error/exception | Error/NSError/NSException          | true        | The error or exception itself. Depending on the type of error, fields will be automatically added to the log record. |
+| attributes      | Dictionary<string, AttributeValue> | false       | Additional attributes you would like to log along with the default ones provided.                                    |
+| thread          | Thread                             | false       | Thread where the error occurred. Add this to include additional attributes related to the thread                     |
+| logger          | Logger                             | false       | Defaults to the Honeycomb error `Logger`. Provide if you want to use a different OpenTelemetry `Logger`              |
 

--- a/README.md
+++ b/README.md
@@ -279,3 +279,34 @@ struct ContentView: View {
 ``` 
 
 In this case, since View B never reports the navigation, if the user navigates to `View A` and then to `View B`, any spans emitted from `View B` will still report `screen.name: "View A"`.
+
+### Manual Exception Logging Handling
+
+Any Errors, NSErrors, or NSExceptions may be recorded as Log records using the `log` method. This can be used for logging 
+any caught exceptions in your own code that will not be logged by our crash instrumentation.
+
+Below is an example of logging an Error object using several custom attributes.
+
+```swift
+do {
+    /// ...
+}
+catch let error {
+    Honeycomb.log(
+        error: error,
+        attributes: [
+            "user.name": AttributeValue.string(currentUser.name),
+            "user.id": AttributeValue.int(currentUser.id)
+        ],
+        thread: Thread.current
+    );
+}
+```
+
+| Argument        | Type                               | Is Required | Description                                                                                             |
+|-----------------|------------------------------------|-------------|---------------------------------------------------------------------------------------------------------|
+| error/exception | Error/NSError/NSException          | true        | The error or exception itself. Depending on the type of error fields will be automatically added        |
+| attributes      | Dictionary<string, AttributeValue> | false       | Additional attributes you would like to log along with the default ones provided.                       |
+| thread          | Thread                             | false       | Thread where the error occurred. Add this to include additional attributes related to the thread        |
+| logger          | Logger                             | false       | Defaults to the Honeycomb error `Logger`. Provide if you want to use a different OpenTelemetry `Logger` |
+

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -267,7 +267,7 @@ public class Honeycomb {
         .merging(attributes, uniquingKeysWith: { (_, last) in last })
 
         if let name = thread?.name {
-            errorAttributes["exception.thread"] = name.attributeValue()
+            errorAttributes["thread.name"] = name.attributeValue()
         }
 
         logError(errorAttributes, logger, timestamp)
@@ -290,7 +290,7 @@ public class Honeycomb {
         .merging(attributes, uniquingKeysWith: { (_, last) in last })
 
         if let name = thread?.name {
-            errorAttributes["exception.thread"] = name.attributeValue()
+            errorAttributes["thread.name"] = name.attributeValue()
         }
 
         logError(errorAttributes, logger, timestamp)

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -222,6 +222,13 @@ public class Honeycomb {
         )
     }
 
+    
+    /// Logs an `NSError`. This can be used for logging any caught exceptions in your own code that will not be logged by our crash instrumentation.
+    /// - Parameters:
+    ///   - error: The `NSError` itself
+    ///   - attributes: Additional attributes you would like to log along with the default ones provided.
+    ///   - thread: Thread where the error occurred. Add this to include additional attributes related to the thread
+    ///   - logger: Defaults to the Honeycomb error `Logger`. Provide if you want to use a different OpenTelemetry `Logger`
     public static func log(
         error: NSError,
         attributes: [String: AttributeValue] = [:],
@@ -246,7 +253,13 @@ public class Honeycomb {
 
         logError(errorAttributes, logger, timestamp)
     }
-
+    
+    /// Logs an `NSException`. This can be used for logging any caught exceptions in your own code that will not be logged by our crash instrumentation.
+    /// - Parameters:
+    ///   - exception: The `NSException` itself
+    ///   - attributes: Additional attributes you would like to log along with the default ones provided.
+    ///   - thread: Thread where the exception occurred. Add this to include additional attributes related to the thread
+    ///   - logger: Defaults to the Honeycomb error `Logger`. Provide if you want to use a different OpenTelemetry `Logger`
     public static func log(
         exception: NSException,
         attributes: [String: AttributeValue] = [:],
@@ -272,7 +285,13 @@ public class Honeycomb {
 
         logError(errorAttributes, logger, timestamp)
     }
-
+    
+    /// Logs an `Error`. This can be used for logging any caught exceptions in your own code that will not be logged by our crash instrumentation.
+    /// - Parameters:
+    ///   - error: The `Error` itself
+    ///   - attributes: Additional attributes you would like to log along with the default ones provided.
+    ///   - thread: Thread where the error occurred. Add this to include additional attributes related to the thread
+    ///   - logger: Defaults to the Honeycomb error `Logger`. Provide if you want to use a different OpenTelemetry `Logger`
     public static func log(
         error: Error,
         attributes: [String: AttributeValue] = [:],

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -222,7 +222,6 @@ public class Honeycomb {
         )
     }
 
-    
     /// Logs an `NSError`. This can be used for logging any caught exceptions in your own code that will not be logged by our crash instrumentation.
     /// - Parameters:
     ///   - error: The `NSError` itself
@@ -253,7 +252,7 @@ public class Honeycomb {
 
         logError(errorAttributes, logger, timestamp)
     }
-    
+
     /// Logs an `NSException`. This can be used for logging any caught exceptions in your own code that will not be logged by our crash instrumentation.
     /// - Parameters:
     ///   - exception: The `NSException` itself
@@ -285,7 +284,7 @@ public class Honeycomb {
 
         logError(errorAttributes, logger, timestamp)
     }
-    
+
     /// Logs an `Error`. This can be used for logging any caught exceptions in your own code that will not be logged by our crash instrumentation.
     /// - Parameters:
     ///   - error: The `Error` itself


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #<enter issue here>

## Short description of the changes
Adds documentation in the readme for manual error logging.

## How to verify that this has the expected result
N/A

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
