### PR TITLE
feat: Use the default resources

### DIFF
--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -64,9 +64,7 @@ public class Honeycomb {
             headers: createKeyValueList(options.logsHeaders)
         )
 
-        // The default constructor includes a bunch of automatic values we want,
-        // so it's important to create a default one and then merge our own.
-        let resource = Resource()
+        let resource = DefaultResources().get()
             .merging(other: Resource(attributes: createAttributeDict(options.resourceAttributes)))
 
         // Traces

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -196,7 +196,7 @@ mk_diag_attr() {
   result=$(span_names_for "io.honeycomb.view" | sort | uniq -c)
   assert_equal "$result" '   7 "View Body"
    7 "View Render"'
-   
+
   # the View Render spans are tracking the views we expect
   total_duration=$(attribute_for_span_key "io.honeycomb.view" "View Render" "view.name" string | sort)
   assert_equal "$total_duration" '"expensive text 1"
@@ -220,7 +220,7 @@ mk_diag_attr() {
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq)
     assert_equal "$result" '"UIKit Menu"'
-    
+
         result=$(attributes_from_span_named "io.honeycomb.uikit" viewDidAppear \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
@@ -250,28 +250,28 @@ mk_diag_attr() {
     assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "Touch Ended" "Simple Button")
     assert_not_empty $(spans_on_view_named "io.honeycomb.uikit" "Touch Ended" "accessibleButton")
     # UISwitch does not support Touch Ended events at this time. Apple sets the view to null.
-    
+
     screen_name_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_name_attr" '"UI KIT SCREEN OVERRIDE"'
-    
+
     screen_path_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.path\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UI KIT SCREEN OVERRIDE\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_path_attr" '"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UI KIT SCREEN OVERRIDE"'
-    
+
     screen_name_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.name\")" \
         | jq "select (.value.stringValue == \"UIKit Menu\").value.stringValue" \
         | uniq
     )
     assert_equal "$screen_name_attr" '"UIKit Menu"'
-    
+
     screen_path_attr=$(attributes_from_span_named "io.honeycomb.uikit" "Touch Began" \
         | jq "select (.key == \"screen.path\")" \
         | jq "select (.value.stringValue == \"SwiftUI.UIKitTabBarController/UIKitNavigationRoot/UIKit Menu\").value.stringValue" \
@@ -310,7 +310,7 @@ mk_diag_attr() {
         | uniq -c)
     root_count=$(echo "$result" | grep "\[\]")
     yosemite_count=$(echo "$result" | grep "Yosemite")
-    
+
     assert_equal "$root_count" '   1 "[]"'
     assert_equal "$yosemite_count" '   1 "[{\"name\":\"Yosemite\"}]"'
 }

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -25,11 +25,16 @@ teardown_file() {
   assert_not_empty "$result"
 }
 
-@test "SDK had default resources" {
-  result=$(resource_attributes_received \
-      | jq 'select (.key == "telemetry.sdk.language").value.stringValue' \
-      | sort | uniq)
-  assert_equal "$result" '"swift"'
+@test "SDK has default resources" {
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "telemetry.sdk.language").value.stringValue' | uniq)" '"swift"'
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "service.name").value.stringValue' | uniq)" '"ios-test"'
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "service.version").value.stringValue' | uniq)" '"1.0 (1)"'
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "device.model.identifier").value.stringValue' | uniq)" '"arm64"'
+  assert_not_empty "$(resource_attributes_received | jq 'select (.key == "device.id").value.stringValue' | uniq)"
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "os.type").value.stringValue' | uniq)" '"darwin"'
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "os.description").value.stringValue' | uniq)" '"iOS Version 17.5 (Build 21F79)"'
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "os.name").value.stringValue' | uniq)" '"iOS"'
+  assert_equal "$(resource_attributes_received | jq 'select (.key == "os.version").value.stringValue' | uniq)" '"17.5.0"'
 }
 
 # A helper just for MetricKit attributes, because there's so many of them.


### PR DESCRIPTION
There is a set of default resources that gets application, device and OS resource information for us. 

Attributes they populate:
- service.name
- service.version
- device.model.identifier
- device.id
- os.type
- os.description
- os.name
- os.version