### PR TITLE
docs: trace propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Honeycomb OpenTelemetry SDK Changelog
 * Add new options to enable/disable built-in auto-instrumentation.
 * Uncaught exception handler to log crashes.
 * Enable telemetry caching for offline support.
+* Documentation added for propagating traces.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ Below is an example of adding the headers to a network request.
 import OpenTelemetryApi
 
 private struct HttpTextMapSetter: Setter {
-    
     func set(carrier: inout [String: String], key: String, value: String) {
         carrier[key] = value
     }
@@ -186,7 +185,7 @@ private struct HttpTextMapSetter: Setter {
 
 private let textMapSetter = HttpTextMapSetter()
 
-func makeBackendRequest(data: Data) {
+func makeBackendRequest(data: Data) async throws {
     let url = URL(string: "https://mybackendservice")
     var request = URLRequest(url: url!)
     request.httpMethod = "POST"
@@ -207,8 +206,6 @@ func makeBackendRequest(data: Data) {
         span.end()
     }
 
-    var allHeaders: [String: String] = []
-
     // This will add the required headers to the `allHeaders` Dictionary
     OpenTelemetry.instance.propagators.textMapPropagator.inject(
         spanContext: span.context,
@@ -222,7 +219,7 @@ func makeBackendRequest(data: Data) {
 
     let session = URLSession(configuration: URLSessionConfiguration.default)
 
-     let (data, response) = try await session.data(for: request)
+    let (data, response) = try await session.data(for: request)
 
      // process your response data as normal
 }

--- a/README.md
+++ b/README.md
@@ -163,6 +163,71 @@ For `.sessionStarted`:
 For `.sessionEnded`:
 * `userInfo["previousSession"]` contains the session just ended.
 
+#### Network
+Network events on `URLSession` will automatically be instrumented. 
+
+##### Trace Propagation 
+If you are connecting your app to a backend service that you wish to view as a unified trace with your app, you
+will need to manually add headers to all your outgoing requests. You must also create a span and set it as the active
+span. The span's context will be used to generate the headers needed for trace propagation.
+
+Below is an example of adding the headers to a network request.
+
+```swift
+
+import OpenTelemetryApi
+
+private struct HttpTextMapSetter: Setter {
+    
+    func set(carrier: inout [String: String], key: String, value: String) {
+        carrier[key] = value
+    }
+}
+
+private let textMapSetter = HttpTextMapSetter()
+
+func makeBackendRequest(data: Data) {
+    let url = URL(string: "https://mybackendservice")
+    var request = URLRequest(url: url!)
+    request.httpMethod = "POST"
+    request.httpBody = data
+
+    let allHeaders: [String: String] = []
+
+    let span = OpenTelemetry.instance.tracerProvider.get(
+        instrumentationName: "mybackendservice.network",
+        instrumentationVersion: getCurrentAppVersion()
+    )
+    .spanBuilder(spanName: "backendRequest")
+    // The span must be made the active span or else the network autoinstrumentation 
+    // will not be attached to the trace.
+    .setActive(true)
+    .startSpan()
+    defer {
+        span.end()
+    }
+
+    var allHeaders: [String: String] = []
+
+    // This will add the required headers to the `allHeaders` Dictionary
+    OpenTelemetry.instance.propagators.textMapPropagator.inject(
+        spanContext: span.context,
+        carrier: &allHeaders,
+        setter: textMapSetter
+    )
+
+    allHeaders.forEach({ (key: String, value: String) in
+        request.setValue(value, forHTTPHeaderField: key)
+    })
+
+    let session = URLSession(configuration: URLSessionConfiguration.default)
+
+     let (data, response) = try await session.data(for: request)
+
+     // process your response data as normal
+}
+```
+
 ## Manual Instrumentation
 ### SwiftUI View Instrumentation
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Users will need to know what steps to take to propagate traces to their own backend. This adds documentation on how to do that.

- Closes #<enter issue here>

## Short description of the changes
You need to create an active span in order for all events to be on the same trace (frontend and backend) this differs
from android where you can just use the Otel Context. Swift uses the span context to set this up.

## How to verify that this has the expected result


---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
