### PR TITLE
rel: v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+## 0.0.6-beta
+
 ### New Features
 
 * Error logging API for manually logging exceptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
-## 0.0.6-beta
+## 0.0.6
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Honeycomb wrapper for [OpenTelemetry](https://opentelemetry.io) on iOS and macOS.
 
-**STATUS: this library is EXPERIMENTAL.** Data shapes are unstable and not safe for production. We are actively seeking feedback to ensure usability.
+**STATUS: this library is in BETA.** Data shapes are stable and safe for production. We are actively seeking feedback to ensure usability.
 
 ## Getting started
 
@@ -27,7 +27,7 @@ If you're using `Package.swift` to manage dependencies...
 ```swift
     dependencies: [
         .package(url: "https://github.com/honeycombio/honeycomb-opentelemetry-swift.git",
-                 from: "0.0.1-alpha")
+                 from: "0.0.6-beta")
     ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you're using `Package.swift` to manage dependencies...
 ```swift
     dependencies: [
         .package(url: "https://github.com/honeycombio/honeycomb-opentelemetry-swift.git",
-                 from: "0.0.6-beta")
+                 from: "0.0.6")
     ],
 ```
 

--- a/Sources/Honeycomb/HoneycombVersion.swift
+++ b/Sources/Honeycomb/HoneycombVersion.swift
@@ -1,4 +1,4 @@
 import Foundation
 
 // TODO: Make a build script that injects this.
-internal let honeycombLibraryVersion = "0.0.6-beta"
+internal let honeycombLibraryVersion = "0.0.6"

--- a/Sources/Honeycomb/HoneycombVersion.swift
+++ b/Sources/Honeycomb/HoneycombVersion.swift
@@ -1,4 +1,4 @@
 import Foundation
 
 // TODO: Make a build script that injects this.
-internal let honeycombLibraryVersion = "0.0.5-alpha"
+internal let honeycombLibraryVersion = "0.0.6-beta"


### PR DESCRIPTION
Prepare 0.0.6 release.

Like the accompanying [Android](https://github.com/honeycombio/honeycomb-opentelemetry-android/pull/62) release, this release also drops the experimental label from the readme and `-alpha` suffix from our version number.

- [x] CHANGELOG is updated
- [x] README is updated with documentation
