### PR TITLE
fix: sometimes crashes dont flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+### Fixes
+
+* Wait for flush to avoid missed crash logs
+
 ## 0.0.6
 
 ### New Features

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f5d6922243fdb0495a47b043b36995028870560219cb8c6ece106a6e686c8363",
+  "originHash" : "39ba00efa019957022bb42156e586c093e5b9e49a5d71928d38e16442ac50570",
   "pins" : [
     {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "6a90b7e77e29f9bda6c2b3a4165a40d6c02cfda1",
-        "version" : "1.23.0"
+        "revision" : "8c5e99d0255c373e0330730d191a3423c57373fb",
+        "version" : "1.24.2"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
       "state" : {
-        "revision" : "f2315d8646432c02338960e85b5fe20417ad6d8d",
-        "version" : "1.12.1"
+        "revision" : "82717beb13edf7931d90ecef2d729bee107efc01",
+        "version" : "1.14.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "05c36b57453d23ea63785d58a7dbc7b70ba1745e",
-        "version" : "1.23.0"
+        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
+        "version" : "1.24.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e17d61f26df0f0e06f58f6977ba05a097a720106",
-        "version" : "1.27.1"
+        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
+        "version" : "1.29.0"
       }
     },
     {

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -337,6 +337,7 @@ public class Honeycomb {
         logger.logRecordBuilder()
             .setTimestamp(timestamp)
             .setAttributes(logAttrs)
+            .setSeverity(.fatal)
             .emit()
     }
 

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -1,7 +1,9 @@
 import Foundation
+import OpenTelemetrySdk
 
 internal class HoneycombUncaughtExceptionHandler {
     private static var initialUncaughtExceptionHandler: ((NSException) -> Void)? = nil
+    private static var logProcessor: LogRecordProcessor? = nil
 
     public static func initializeUnhandledExceptionInstrumentation() {
         HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler =
@@ -9,6 +11,9 @@ internal class HoneycombUncaughtExceptionHandler {
 
         NSSetUncaughtExceptionHandler { exception in
             Honeycomb.log(exception: exception, thread: Thread.current)
+            
+            // Wait
+            Thread.sleep(forTimeInterval: 10.0)
 
             if let initialHanlder = HoneycombUncaughtExceptionHandler
                 .initialUncaughtExceptionHandler

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OpenTelemetrySdk
 
 internal class HoneycombUncaughtExceptionHandler {
     private static var initialUncaughtExceptionHandler: ((NSException) -> Void)? = nil

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -11,7 +11,7 @@ internal class HoneycombUncaughtExceptionHandler {
 
         NSSetUncaughtExceptionHandler { exception in
             Honeycomb.log(exception: exception, thread: Thread.current)
-            
+
             // Wait
             Thread.sleep(forTimeInterval: 3.0)
 

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -3,7 +3,6 @@ import OpenTelemetrySdk
 
 internal class HoneycombUncaughtExceptionHandler {
     private static var initialUncaughtExceptionHandler: ((NSException) -> Void)? = nil
-    private static var logProcessor: LogRecordProcessor? = nil
 
     public static func initializeUnhandledExceptionInstrumentation() {
         HoneycombUncaughtExceptionHandler.initialUncaughtExceptionHandler =

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -13,7 +13,7 @@ internal class HoneycombUncaughtExceptionHandler {
             Honeycomb.log(exception: exception, thread: Thread.current)
             
             // Wait
-            Thread.sleep(forTimeInterval: 10.0)
+            Thread.sleep(forTimeInterval: 3.0)
 
             if let initialHanlder = HoneycombUncaughtExceptionHandler
                 .initialUncaughtExceptionHandler

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -11,7 +11,7 @@ internal class HoneycombUncaughtExceptionHandler {
         NSSetUncaughtExceptionHandler { exception in
             Honeycomb.log(exception: exception, thread: Thread.current)
 
-            // Wait
+            // App is about to close taking Otel with it, give it some time to finish
             Thread.sleep(forTimeInterval: 3.0)
 
             if let initialHanlder = HoneycombUncaughtExceptionHandler


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Due to the flakiness of the underlying `flush` methods, sometimes exception logs do not get sent before the app crashes.

- Closes #<enter issue here>

## Short description of the changes

We are adding a 3 second wait to allow the crash exception to finish exporting.

## How to verify that this has the expected result

---

- [X] CHANGELOG is updated
- [N/A] README is updated with documentation
