### PR TITLE
maint: add CI for all the platforms that we support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - checkout
       - run: xcodebuild -version
-      - run: xcodebuild test -scheme honeycomb-opentelemetry-swift -destination << parameters.destination >>
+      - run: xcodebuild -scheme honeycomb-opentelemetry-swift -destination << parameters.destination >>
 
   tests:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,18 @@ jobs:
       - checkout
       - run: make lint
 
+  build:
+    parameters:
+      destination:
+        type: string
+    macos:
+      xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
+    steps:
+      - checkout
+      - run: xcodebuild -version
+      - run: xcodebuild test -scheme honeycomb-opentelemetry-swift -destination << parameters.destination >>
+
   tests:
     macos:
       xcode: 15.4.0
@@ -86,6 +98,14 @@ workflows:
                 - main
     jobs:
       - lint
+      - build:
+          matrix:
+            parameters:
+              destination:
+                - generic/platform=macOS
+                - generic/platform=iOS
+                - generic/platform=tvOS
+                - generic/platform=watchOS
       - tests
       - smoke_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,15 @@ workflows:
     jobs:
       - lint:
           <<: *filters_always
+      - build:
+          <<: *filters_always
+          matrix:
+            parameters:
+              destination:
+                - generic/platform=macOS
+                - generic/platform=iOS
+                - generic/platform=tvOS
+                - generic/platform=watchOS
       - tests:
           <<: *filters_always
       - smoke_tests:

--- a/Sources/Honeycomb/AttributeValueExtensions.swift
+++ b/Sources/Honeycomb/AttributeValueExtensions.swift
@@ -1,5 +1,7 @@
 import OpenTelemetryApi
+#if canImport(MetricKit)
 import MetricKit
+#endif
 
 /// A protocol to make it easier to write generic functions for AttributeValues.
 protocol AttributeValueConvertable {
@@ -28,6 +30,7 @@ extension [String]: AttributeValueConvertable {
     }
 }
 
+#if canImport(MetricKit)
 extension TimeInterval: AttributeValueConvertable {
     func attributeValue() -> AttributeValue {
         // The OTel standard for time durations is seconds, which is also what TimeInterval is.
@@ -47,3 +50,4 @@ extension Measurement: AttributeValueConvertable {
         return AttributeValue.double(value)
     }
 }
+#endif

--- a/Sources/Honeycomb/AttributeValueExtensions.swift
+++ b/Sources/Honeycomb/AttributeValueExtensions.swift
@@ -1,0 +1,49 @@
+import OpenTelemetryApi
+import MetricKit
+
+/// A protocol to make it easier to write generic functions for AttributeValues.
+protocol AttributeValueConvertable {
+    func attributeValue() -> AttributeValue
+}
+
+extension Int: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        AttributeValue.int(self)
+    }
+}
+extension Bool: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        AttributeValue.bool(self)
+    }
+}
+extension String: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        AttributeValue.string(self)
+    }
+}
+
+extension [String]: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        AttributeValue.array(AttributeArray(values: self.map { AttributeValue.string($0) }))
+    }
+}
+
+extension TimeInterval: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        // The OTel standard for time durations is seconds, which is also what TimeInterval is.
+        // https://opentelemetry.io/docs/specs/semconv/general/metrics/
+        AttributeValue.double(self)
+    }
+}
+extension Measurement: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        // Convert to the "base unit", such as seconds or bytes.
+        let value =
+            if let unit = self.unit as? Dimension {
+                unit.converter.baseUnitValue(fromValue: self.value)
+            } else {
+                self.value
+            }
+        return AttributeValue.double(value)
+    }
+}

--- a/Sources/Honeycomb/AttributeValueExtensions.swift
+++ b/Sources/Honeycomb/AttributeValueExtensions.swift
@@ -1,8 +1,5 @@
+import Foundation
 import OpenTelemetryApi
-
-#if canImport(MetricKit)
-    import MetricKit
-#endif
 
 /// A protocol to make it easier to write generic functions for AttributeValues.
 protocol AttributeValueConvertable {
@@ -31,24 +28,23 @@ extension [String]: AttributeValueConvertable {
     }
 }
 
-#if canImport(MetricKit)
-    extension TimeInterval: AttributeValueConvertable {
-        func attributeValue() -> AttributeValue {
-            // The OTel standard for time durations is seconds, which is also what TimeInterval is.
-            // https://opentelemetry.io/docs/specs/semconv/general/metrics/
-            AttributeValue.double(self)
-        }
+extension TimeInterval: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        // The OTel standard for time durations is seconds, which is also what TimeInterval is.
+        // https://opentelemetry.io/docs/specs/semconv/general/metrics/
+        AttributeValue.double(self)
     }
-    extension Measurement: AttributeValueConvertable {
-        func attributeValue() -> AttributeValue {
-            // Convert to the "base unit", such as seconds or bytes.
-            let value =
-                if let unit = self.unit as? Dimension {
-                    unit.converter.baseUnitValue(fromValue: self.value)
-                } else {
-                    self.value
-                }
-            return AttributeValue.double(value)
-        }
+}
+
+extension Measurement: AttributeValueConvertable {
+    func attributeValue() -> AttributeValue {
+        // Convert to the "base unit", such as seconds or bytes.
+        let value =
+            if let unit = self.unit as? Dimension {
+                unit.converter.baseUnitValue(fromValue: self.value)
+            } else {
+                self.value
+            }
+        return AttributeValue.double(value)
     }
-#endif
+}

--- a/Sources/Honeycomb/AttributeValueExtensions.swift
+++ b/Sources/Honeycomb/AttributeValueExtensions.swift
@@ -1,6 +1,7 @@
 import OpenTelemetryApi
+
 #if canImport(MetricKit)
-import MetricKit
+    import MetricKit
 #endif
 
 /// A protocol to make it easier to write generic functions for AttributeValues.
@@ -31,23 +32,23 @@ extension [String]: AttributeValueConvertable {
 }
 
 #if canImport(MetricKit)
-extension TimeInterval: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        // The OTel standard for time durations is seconds, which is also what TimeInterval is.
-        // https://opentelemetry.io/docs/specs/semconv/general/metrics/
-        AttributeValue.double(self)
+    extension TimeInterval: AttributeValueConvertable {
+        func attributeValue() -> AttributeValue {
+            // The OTel standard for time durations is seconds, which is also what TimeInterval is.
+            // https://opentelemetry.io/docs/specs/semconv/general/metrics/
+            AttributeValue.double(self)
+        }
     }
-}
-extension Measurement: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        // Convert to the "base unit", such as seconds or bytes.
-        let value =
-            if let unit = self.unit as? Dimension {
-                unit.converter.baseUnitValue(fromValue: self.value)
-            } else {
-                self.value
-            }
-        return AttributeValue.double(value)
+    extension Measurement: AttributeValueConvertable {
+        func attributeValue() -> AttributeValue {
+            // Convert to the "base unit", such as seconds or bytes.
+            let value =
+                if let unit = self.unit as? Dimension {
+                    unit.converter.baseUnitValue(fromValue: self.value)
+                } else {
+                    self.value
+                }
+            return AttributeValue.double(value)
+        }
     }
-}
 #endif

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -127,14 +127,14 @@ public class Honeycomb {
             )
 
         #if os(iOS) && !targetEnvironment(macCatalyst)
-        do {
-            let networkMonitor = try NetworkMonitor()
-            tracerProviderBuilder =
-                tracerProviderBuilder
-                .add(spanProcessor: NetworkStatusSpanProcessor(monitor: networkMonitor))
-        } catch {
-            NSLog("Unable to create NetworkMonitor: \(error)")
-        }
+            do {
+                let networkMonitor = try NetworkMonitor()
+                tracerProviderBuilder =
+                    tracerProviderBuilder
+                    .add(spanProcessor: NetworkStatusSpanProcessor(monitor: networkMonitor))
+            } catch {
+                NSLog("Unable to create NetworkMonitor: \(error)")
+            }
         #endif
 
         let tracerProvider =

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -30,9 +30,11 @@ private func createKeyValueList(_ dict: [String: String]) -> [(String, String)] 
 }
 
 public class Honeycomb {
+    #if canImport(MXMetricManager)
     @available(iOS 13.0, macOS 12.0, *)
     static private let metricKitSubscriber = MetricKitSubscriber()
-
+    #endif
+    
     static public func configure(options: HoneycombOptions) throws {
 
         if options.debug {
@@ -226,11 +228,13 @@ public class Honeycomb {
             HoneycombUncaughtExceptionHandler.initializeUnhandledExceptionInstrumentation()
         }
 
-        if #available(iOS 13.0, macOS 12.0, *) {
+        #if canImport(MXMetricManager)
+        if #available(tvOS 16.0, iOS 13.0, macOS 12.0, *) {
             if options.metricKitInstrumentationEnabled {
                 MXMetricManager.shared.add(self.metricKitSubscriber)
             }
         }
+        #endif
     }
 
     private static let errorLoggerInstrumentationName = "io.honeycomb.error"
@@ -350,7 +354,7 @@ public class Honeycomb {
             .emit()
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(tvOS 16.0, iOS 16.0, macOS 13.0, *)
     public static func setCurrentScreen(
         prefix: String? = nil,
         path: NavigationPath,

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -33,8 +33,9 @@ private func createKeyValueList(_ dict: [String: String]) -> [(String, String)] 
 }
 
 public class Honeycomb {
-    @available(iOS 13.0, macOS 12.0, *)
-    static private let metricKitSubscriber = MetricKitSubscriber()
+    #if canImport(MetricKit) && !os(tvOS) && !os(macOS)
+        static private let metricKitSubscriber = MetricKitSubscriber()
+    #endif
 
     static public func configure(options: HoneycombOptions) throws {
 
@@ -229,11 +230,13 @@ public class Honeycomb {
             HoneycombUncaughtExceptionHandler.initializeUnhandledExceptionInstrumentation()
         }
 
-        if #available(tvOS 16.0, iOS 13.0, macOS 12.0, *) {
-            if options.metricKitInstrumentationEnabled {
-                MXMetricManager.shared.add(self.metricKitSubscriber)
+        #if canImport(MetricKit) && !os(tvOS) && !os(macOS)
+            if #available(iOS 13.0, *) {
+                if options.metricKitInstrumentationEnabled {
+                    MXMetricManager.shared.add(self.metricKitSubscriber)
+                }
             }
-        }
+        #endif
     }
 
     private static let errorLoggerInstrumentationName = "io.honeycomb.error"

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -126,6 +126,7 @@ public class Honeycomb {
                 )
             )
 
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         do {
             let networkMonitor = try NetworkMonitor()
             tracerProviderBuilder =
@@ -134,6 +135,7 @@ public class Honeycomb {
         } catch {
             NSLog("Unable to create NetworkMonitor: \(error)")
         }
+        #endif
 
         let tracerProvider =
             tracerProviderBuilder

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -33,10 +33,8 @@ private func createKeyValueList(_ dict: [String: String]) -> [(String, String)] 
 }
 
 public class Honeycomb {
-    #if canImport(MXMetricManager)
-        @available(iOS 13.0, macOS 12.0, *)
-        static private let metricKitSubscriber = MetricKitSubscriber()
-    #endif
+    @available(iOS 13.0, macOS 12.0, *)
+    static private let metricKitSubscriber = MetricKitSubscriber()
 
     static public func configure(options: HoneycombOptions) throws {
 
@@ -231,13 +229,11 @@ public class Honeycomb {
             HoneycombUncaughtExceptionHandler.initializeUnhandledExceptionInstrumentation()
         }
 
-        #if canImport(MXMetricManager)
-            if #available(tvOS 16.0, iOS 13.0, macOS 12.0, *) {
-                if options.metricKitInstrumentationEnabled {
-                    MXMetricManager.shared.add(self.metricKitSubscriber)
-                }
+        if #available(tvOS 16.0, iOS 13.0, macOS 12.0, *) {
+            if options.metricKitInstrumentationEnabled {
+                MXMetricManager.shared.add(self.metricKitSubscriber)
             }
-        #endif
+        }
     }
 
     private static let errorLoggerInstrumentationName = "io.honeycomb.error"

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -1,9 +1,6 @@
 import BaggagePropagationProcessor
 import Foundation
 import GRPC
-#if canImport(MetricKit)
-import MetricKit
-#endif
 import NIO
 import NetworkStatus
 import OpenTelemetryApi
@@ -14,6 +11,10 @@ import OpenTelemetrySdk
 import ResourceExtension
 import StdoutExporter
 import SwiftUI
+
+#if canImport(MetricKit)
+    import MetricKit
+#endif
 
 private func createAttributeDict(_ dict: [String: String]) -> [String: AttributeValue] {
     var result: [String: AttributeValue] = [:]
@@ -33,10 +34,10 @@ private func createKeyValueList(_ dict: [String: String]) -> [(String, String)] 
 
 public class Honeycomb {
     #if canImport(MXMetricManager)
-    @available(iOS 13.0, macOS 12.0, *)
-    static private let metricKitSubscriber = MetricKitSubscriber()
+        @available(iOS 13.0, macOS 12.0, *)
+        static private let metricKitSubscriber = MetricKitSubscriber()
     #endif
-    
+
     static public func configure(options: HoneycombOptions) throws {
 
         if options.debug {
@@ -231,11 +232,11 @@ public class Honeycomb {
         }
 
         #if canImport(MXMetricManager)
-        if #available(tvOS 16.0, iOS 13.0, macOS 12.0, *) {
-            if options.metricKitInstrumentationEnabled {
-                MXMetricManager.shared.add(self.metricKitSubscriber)
+            if #available(tvOS 16.0, iOS 13.0, macOS 12.0, *) {
+                if options.metricKitInstrumentationEnabled {
+                    MXMetricManager.shared.add(self.metricKitSubscriber)
+                }
             }
-        }
         #endif
     }
 

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -1,7 +1,9 @@
 import BaggagePropagationProcessor
 import Foundation
 import GRPC
+#if canImport(MetricKit)
 import MetricKit
+#endif
 import NIO
 import NetworkStatus
 import OpenTelemetryApi
@@ -105,7 +107,7 @@ public class Honeycomb {
         let spanProcessor = CompositeSpanProcessor()
         spanProcessor.addSpanProcessor(BatchSpanProcessor(spanExporter: spanExporter))
 
-        #if canImport(UIKit)
+        #if canImport(UIKit) && !os(watchOS)
             spanProcessor.addSpanProcessor(
                 UIDeviceSpanProcessor()
             )
@@ -216,7 +218,7 @@ public class Honeycomb {
         if options.urlSessionInstrumentationEnabled {
             installNetworkInstrumentation(options: options)
         }
-        #if canImport(UIKit)
+        #if canImport(UIKit) && !os(watchOS)
             if options.uiKitInstrumentationEnabled {
                 installUINavigationInstrumentation()
             }
@@ -354,7 +356,7 @@ public class Honeycomb {
             .emit()
     }
 
-    @available(tvOS 16.0, iOS 16.0, macOS 13.0, *)
+    @available(tvOS 16.0, iOS 16.0, macOS 13.0, watchOS 9, *)
     public static func setCurrentScreen(
         prefix: String? = nil,
         path: NavigationPath,

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -27,7 +27,7 @@ internal class HoneycombNavigationProcessor {
         setupAppLifecycleTracking()
     }
 
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(tvOS 16.0, iOS 16.0, macOS 13.0, *)
     func reportNavigation(prefix: String? = nil, path: NavigationPath, reason: String? = nil) {
         if let codablePath = path.codable {
             reportNavigation(path: codablePath, reason: reason)
@@ -165,7 +165,7 @@ internal class HoneycombNavigationProcessor {
 }
 
 extension View {
-    @available(iOS 16.0, macOS 13.0, *)
+    @available(tvOS 16.0, iOS 16.0, macOS 13.0, *)
     public func instrumentNavigation(
         prefix: String? = nil,
         path: NavigationPath,

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -27,7 +27,7 @@ internal class HoneycombNavigationProcessor {
         setupAppLifecycleTracking()
     }
 
-    @available(tvOS 16.0, iOS 16.0, macOS 13.0, *)
+    @available(tvOS 16.0, iOS 16.0, macOS 13.0, watchOS 9, *)
     func reportNavigation(prefix: String? = nil, path: NavigationPath, reason: String? = nil) {
         if let codablePath = path.codable {
             reportNavigation(path: codablePath, reason: reason)
@@ -90,7 +90,7 @@ internal class HoneycombNavigationProcessor {
     }
 
     private func setupAppLifecycleTracking() {
-        #if canImport(UIKit)
+        #if canImport(UIKit) && !os(watchOS)
             let notificationCenter = NotificationCenter.default
 
             // Monitor foreground/background state changes
@@ -165,7 +165,7 @@ internal class HoneycombNavigationProcessor {
 }
 
 extension View {
-    @available(tvOS 16.0, iOS 16.0, macOS 13.0, *)
+    @available(tvOS 16.0, iOS 16.0, macOS 13.0, watchOS 9, *)
     public func instrumentNavigation(
         prefix: String? = nil,
         path: NavigationPath,

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -1,3 +1,4 @@
+#if canImport(MXMetricManager)
 import Foundation
 import MetricKit
 import OpenTelemetryApi
@@ -19,55 +20,6 @@ class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
         for payload in payloads {
             reportDiagnostics(payload: payload)
         }
-    }
-}
-
-// MARK: - AttributeValue helpers
-
-/// A protocol to make it easier to write generic functions for AttributeValues.
-protocol AttributeValueConvertable {
-    func attributeValue() -> AttributeValue
-}
-
-extension Int: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        AttributeValue.int(self)
-    }
-}
-extension Bool: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        AttributeValue.bool(self)
-    }
-}
-extension String: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        AttributeValue.string(self)
-    }
-}
-
-extension [String]: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        AttributeValue.array(AttributeArray(values: self.map { AttributeValue.string($0) }))
-    }
-}
-
-extension TimeInterval: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        // The OTel standard for time durations is seconds, which is also what TimeInterval is.
-        // https://opentelemetry.io/docs/specs/semconv/general/metrics/
-        AttributeValue.double(self)
-    }
-}
-extension Measurement: AttributeValueConvertable {
-    func attributeValue() -> AttributeValue {
-        // Convert to the "base unit", such as seconds or bytes.
-        let value =
-            if let unit = self.unit as? Dimension {
-                unit.converter.baseUnitValue(fromValue: self.value)
-            } else {
-                self.value
-            }
-        return AttributeValue.double(value)
     }
 }
 
@@ -464,3 +416,4 @@ public func reportDiagnostics(payload: MXDiagnosticPayload) {
         return attrs
     }
 }
+#endif

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -1,21 +1,19 @@
-#if canImport(MXMetricManager)
+#if canImport(MetricKit) && !os(tvOS) && !os(macOS)
     import Foundation
     import MetricKit
     import OpenTelemetryApi
 
     private let metricKitInstrumentationName = "io.honeycomb.metrickit"
 
-    @available(iOS 13.0, macOS 12.0, *)
+    @available(iOS 13.0, *)
     class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
-        #if os(iOS)
-            func didReceive(_ payloads: [MXMetricPayload]) {
-                for payload in payloads {
-                    reportMetrics(payload: payload)
-                }
+        func didReceive(_ payloads: [MXMetricPayload]) {
+            for payload in payloads {
+                reportMetrics(payload: payload)
             }
-        #endif
+        }
 
-        @available(iOS 14.0, macOS 12.0, *)
+        @available(iOS 14.0, *)
         func didReceive(_ payloads: [MXDiagnosticPayload]) {
             for payload in payloads {
                 reportDiagnostics(payload: payload)
@@ -35,7 +33,7 @@
     }
 
     /// Estimates the average value of the whole histogram.
-    @available(iOS 13.0, macOS 12.0, *)
+    @available(iOS 13.0, *)
     func estimateHistogramAverage<UnitType>(_ histogram: MXHistogram<UnitType>) -> Measurement<
         UnitType
     >? {
@@ -56,301 +54,299 @@
         return estimatedSum.map { $0 / sampleCount }
     }
 
-    #if os(iOS)
-        public func reportMetrics(payload: MXMetricPayload) {
-            let span = getMetricKitTracer().spanBuilder(spanName: "MXMetricPayload")
-                .setStartTime(time: payload.timeStampBegin)
-                .startSpan()
-            defer { span.end(time: payload.timeStampEnd) }
+    public func reportMetrics(payload: MXMetricPayload) {
+        let span = getMetricKitTracer().spanBuilder(spanName: "MXMetricPayload")
+            .setStartTime(time: payload.timeStampBegin)
+            .startSpan()
+        defer { span.end(time: payload.timeStampEnd) }
 
-            // There are so many nested metrics we want to capture, it's worth setting up some helper
-            // methods to reduce the amount of repeated code.
+        // There are so many nested metrics we want to capture, it's worth setting up some helper
+        // methods to reduce the amount of repeated code.
 
-            var namespaceStack = ["metrickit"]
+        var namespaceStack = ["metrickit"]
 
-            func captureMetric(key: String, value: AttributeValueConvertable) {
-                let namespace = namespaceStack.joined(separator: ".")
-                span.setAttribute(key: "\(namespace).\(key)", value: value.attributeValue())
-            }
+        func captureMetric(key: String, value: AttributeValueConvertable) {
+            let namespace = namespaceStack.joined(separator: ".")
+            span.setAttribute(key: "\(namespace).\(key)", value: value.attributeValue())
+        }
 
-            // Helper functions for sending histograms, specifically.
-            func captureMetric<UnitType>(key: String, value histogram: MXHistogram<UnitType>) {
-                if let average = estimateHistogramAverage(histogram) {
-                    captureMetric(key: key, value: average)
-                }
+        // Helper functions for sending histograms, specifically.
+        func captureMetric<UnitType>(key: String, value histogram: MXHistogram<UnitType>) {
+            if let average = estimateHistogramAverage(histogram) {
+                captureMetric(key: key, value: average)
             }
+        }
 
-            // This helper makes it easier to process each category without typing its name repeatedly.
-            func withCategory<T>(_ parent: T?, _ namespace: String, using closure: (T) -> Void) {
-                namespaceStack.append(namespace)
-                if let p = parent {
-                    closure(p)
-                }
-                namespaceStack.removeLast()
+        // This helper makes it easier to process each category without typing its name repeatedly.
+        func withCategory<T>(_ parent: T?, _ namespace: String, using closure: (T) -> Void) {
+            namespaceStack.append(namespace)
+            if let p = parent {
+                closure(p)
             }
+            namespaceStack.removeLast()
+        }
 
-            // These attribute names follow the guidelines at
-            // https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/
+        // These attribute names follow the guidelines at
+        // https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/
 
-            captureMetric(
-                key: "includes_multiple_application_versions",
-                value: payload.includesMultipleApplicationVersions
-            )
-            captureMetric(
-                key: "latest_application_version",
-                value: payload.latestApplicationVersion
-            )
-            captureMetric(
-                key: "timestamp_begin",
-                value: payload.timeStampBegin.timeIntervalSince1970
-            )
-            captureMetric(key: "timestamp_end", value: payload.timeStampEnd.timeIntervalSince1970)
+        captureMetric(
+            key: "includes_multiple_application_versions",
+            value: payload.includesMultipleApplicationVersions
+        )
+        captureMetric(
+            key: "latest_application_version",
+            value: payload.latestApplicationVersion
+        )
+        captureMetric(
+            key: "timestamp_begin",
+            value: payload.timeStampBegin.timeIntervalSince1970
+        )
+        captureMetric(key: "timestamp_end", value: payload.timeStampEnd.timeIntervalSince1970)
 
-            withCategory(payload.metaData, "metadata") {
-                captureMetric(key: "app_build_version", value: $0.applicationBuildVersion)
-                captureMetric(key: "device_type", value: $0.deviceType)
-                captureMetric(key: "os_version", value: $0.osVersion)
-                captureMetric(key: "region_format", value: $0.regionFormat)
-                if #available(iOS 14.0, *) {
-                    captureMetric(key: "platform_arch", value: $0.platformArchitecture)
-                }
-                if #available(iOS 17.0, *) {
-                    captureMetric(key: "is_test_flight_app", value: $0.isTestFlightApp)
-                    captureMetric(key: "low_power_mode_enabled", value: $0.lowPowerModeEnabled)
-                    captureMetric(key: "pid", value: Int($0.pid))
-                }
-            }
-            withCategory(payload.applicationLaunchMetrics, "app_launch") {
-                captureMetric(
-                    key: "time_to_first_draw_average",
-                    value: $0.histogrammedTimeToFirstDraw
-                )
-                captureMetric(
-                    key: "app_resume_time_average",
-                    value: $0.histogrammedApplicationResumeTime
-                )
-                if #available(iOS 15.2, *) {
-                    captureMetric(
-                        key: "optimized_time_to_first_draw_average",
-                        value: $0.histogrammedOptimizedTimeToFirstDraw
-                    )
-                }
-                if #available(iOS 16.0, *) {
-                    captureMetric(
-                        key: "extended_launch_average",
-                        value: $0.histogrammedExtendedLaunch
-                    )
-                }
-            }
-            withCategory(payload.applicationResponsivenessMetrics, "app_responsiveness") {
-                captureMetric(key: "hang_time_average", value: $0.histogrammedApplicationHangTime)
-            }
-            withCategory(payload.cellularConditionMetrics, "cellular_condition") {
-                captureMetric(key: "bars_average", value: $0.histogrammedCellularConditionTime)
-            }
-            withCategory(payload.locationActivityMetrics, "location_activity") {
-                captureMetric(key: "best_accuracy_time", value: $0.cumulativeBestAccuracyTime)
-                captureMetric(
-                    key: "best_accuracy_for_nav_time",
-                    value: $0.cumulativeBestAccuracyForNavigationTime
-                )
-                captureMetric(
-                    key: "accuracy_10m_time",
-                    value: $0.cumulativeNearestTenMetersAccuracyTime
-                )
-                captureMetric(
-                    key: "accuracy_100m_time",
-                    value: $0.cumulativeHundredMetersAccuracyTime
-                )
-                captureMetric(key: "accuracy_1km_time", value: $0.cumulativeKilometerAccuracyTime)
-                captureMetric(
-                    key: "accuracy_3km_time",
-                    value: $0.cumulativeThreeKilometersAccuracyTime
-                )
-            }
-            withCategory(payload.networkTransferMetrics, "network_transfer") {
-                captureMetric(key: "cellular_download", value: $0.cumulativeCellularDownload)
-                captureMetric(key: "cellular_upload", value: $0.cumulativeCellularUpload)
-                captureMetric(key: "wifi_download", value: $0.cumulativeWifiDownload)
-                captureMetric(key: "wifi_upload", value: $0.cumulativeWifiUpload)
-            }
+        withCategory(payload.metaData, "metadata") {
+            captureMetric(key: "app_build_version", value: $0.applicationBuildVersion)
+            captureMetric(key: "device_type", value: $0.deviceType)
+            captureMetric(key: "os_version", value: $0.osVersion)
+            captureMetric(key: "region_format", value: $0.regionFormat)
             if #available(iOS 14.0, *) {
-                withCategory(payload.applicationExitMetrics, "app_exit") {
-                    withCategory($0.foregroundExitData, "foreground") {
-                        captureMetric(
-                            key: "abnormal_exit_count",
-                            value: $0.cumulativeAbnormalExitCount
-                        )
-                        captureMetric(
-                            key: "app_watchdog_exit_count",
-                            value: $0.cumulativeAppWatchdogExitCount
-                        )
-                        captureMetric(
-                            key: "bad_access_exit_count",
-                            value: $0.cumulativeBadAccessExitCount
-                        )
-                        captureMetric(
-                            key: "illegal_instruction_exit_count",
-                            value: $0.cumulativeIllegalInstructionExitCount
-                        )
-                        captureMetric(
-                            key: "memory_resource_limit_exit-count",
-                            value: $0.cumulativeMemoryResourceLimitExitCount
-                        )
-                        captureMetric(
-                            key: "normal_app_exit_count",
-                            value: $0.cumulativeNormalAppExitCount
-                        )
-                    }
-
-                    withCategory($0.backgroundExitData, "background") {
-                        captureMetric(
-                            key: "abnormal_exit_count",
-                            value: $0.cumulativeAbnormalExitCount
-                        )
-                        captureMetric(
-                            key: "app_watchdog_exit_count",
-                            value: $0.cumulativeAppWatchdogExitCount
-                        )
-                        captureMetric(
-                            key: "bad_access-exit_count",
-                            value: $0.cumulativeBadAccessExitCount
-                        )
-                        captureMetric(
-                            key: "normal_app_exit_count",
-                            value: $0.cumulativeNormalAppExitCount
-                        )
-                        captureMetric(
-                            key: "memory_pressure_exit_count",
-                            value: $0.cumulativeMemoryPressureExitCount
-                        )
-                        captureMetric(
-                            key: "illegal_instruction_exit_count",
-                            value: $0.cumulativeIllegalInstructionExitCount
-                        )
-                        captureMetric(
-                            key: "cpu_resource_limit_exit_count",
-                            value: $0.cumulativeCPUResourceLimitExitCount
-                        )
-                        captureMetric(
-                            key: "memory_resource_limit_exit_count",
-                            value: $0.cumulativeMemoryResourceLimitExitCount
-                        )
-                        captureMetric(
-                            key: "suspended_with_locked_file_exit_count",
-                            value: $0.cumulativeSuspendedWithLockedFileExitCount
-                        )
-                        captureMetric(
-                            key: "background_task_assertion_timeout_exit_count",
-                            value: $0.cumulativeBackgroundTaskAssertionTimeoutExitCount
-                        )
-                    }
-                }
+                captureMetric(key: "platform_arch", value: $0.platformArchitecture)
             }
-            if #available(iOS 14.0, *) {
-                withCategory(payload.animationMetrics, "animation") {
-                    captureMetric(key: "scroll_hitch_time_ratio", value: $0.scrollHitchTimeRatio)
-                }
+            if #available(iOS 17.0, *) {
+                captureMetric(key: "is_test_flight_app", value: $0.isTestFlightApp)
+                captureMetric(key: "low_power_mode_enabled", value: $0.lowPowerModeEnabled)
+                captureMetric(key: "pid", value: Int($0.pid))
             }
-            withCategory(payload.applicationTimeMetrics, "app_time") {
+        }
+        withCategory(payload.applicationLaunchMetrics, "app_launch") {
+            captureMetric(
+                key: "time_to_first_draw_average",
+                value: $0.histogrammedTimeToFirstDraw
+            )
+            captureMetric(
+                key: "app_resume_time_average",
+                value: $0.histogrammedApplicationResumeTime
+            )
+            if #available(iOS 15.2, *) {
                 captureMetric(
-                    key: "foreground_time",
-                    value: $0.cumulativeForegroundTime
-                )
-                captureMetric(
-                    key: "background_time",
-                    value: $0.cumulativeBackgroundTime
-                )
-                captureMetric(
-                    key: "background_audio_time",
-                    value: $0.cumulativeBackgroundAudioTime
-                )
-                captureMetric(
-                    key: "background_location_time",
-                    value: $0.cumulativeBackgroundLocationTime
+                    key: "optimized_time_to_first_draw_average",
+                    value: $0.histogrammedOptimizedTimeToFirstDraw
                 )
             }
-            withCategory(payload.cellularConditionMetrics, "cellular_condition") {
+            if #available(iOS 16.0, *) {
                 captureMetric(
-                    key: "cellular_condition_time_average",
-                    value: $0.histogrammedCellularConditionTime
+                    key: "extended_launch_average",
+                    value: $0.histogrammedExtendedLaunch
                 )
             }
-            withCategory(payload.cpuMetrics, "cpu") {
-                if #available(iOS 14.0, *) {
-                    captureMetric(key: "instruction_count", value: $0.cumulativeCPUInstructions)
-                }
-                captureMetric(key: "cpu_time", value: $0.cumulativeCPUTime)
-            }
-            withCategory(payload.gpuMetrics, "gpu") {
-                captureMetric(key: "time", value: $0.cumulativeGPUTime)
-            }
-            withCategory(payload.diskIOMetrics, "diskio") {
-                captureMetric(key: "logical_write_count", value: $0.cumulativeLogicalWrites)
-            }
-            withCategory(payload.memoryMetrics, "memory") {
-                captureMetric(key: "peak_memory_usage", value: $0.peakMemoryUsage)
-                captureMetric(
-                    key: "suspended_memory_average",
-                    value: $0.averageSuspendedMemory.averageMeasurement
-                )
-            }
-            // Display metrics *only* has pixel luminance, and it's an MXAverage value.
-            withCategory(payload.displayMetrics, "display") {
-                if let averagePixelLuminance = $0.averagePixelLuminance {
+        }
+        withCategory(payload.applicationResponsivenessMetrics, "app_responsiveness") {
+            captureMetric(key: "hang_time_average", value: $0.histogrammedApplicationHangTime)
+        }
+        withCategory(payload.cellularConditionMetrics, "cellular_condition") {
+            captureMetric(key: "bars_average", value: $0.histogrammedCellularConditionTime)
+        }
+        withCategory(payload.locationActivityMetrics, "location_activity") {
+            captureMetric(key: "best_accuracy_time", value: $0.cumulativeBestAccuracyTime)
+            captureMetric(
+                key: "best_accuracy_for_nav_time",
+                value: $0.cumulativeBestAccuracyForNavigationTime
+            )
+            captureMetric(
+                key: "accuracy_10m_time",
+                value: $0.cumulativeNearestTenMetersAccuracyTime
+            )
+            captureMetric(
+                key: "accuracy_100m_time",
+                value: $0.cumulativeHundredMetersAccuracyTime
+            )
+            captureMetric(key: "accuracy_1km_time", value: $0.cumulativeKilometerAccuracyTime)
+            captureMetric(
+                key: "accuracy_3km_time",
+                value: $0.cumulativeThreeKilometersAccuracyTime
+            )
+        }
+        withCategory(payload.networkTransferMetrics, "network_transfer") {
+            captureMetric(key: "cellular_download", value: $0.cumulativeCellularDownload)
+            captureMetric(key: "cellular_upload", value: $0.cumulativeCellularUpload)
+            captureMetric(key: "wifi_download", value: $0.cumulativeWifiDownload)
+            captureMetric(key: "wifi_upload", value: $0.cumulativeWifiUpload)
+        }
+        if #available(iOS 14.0, *) {
+            withCategory(payload.applicationExitMetrics, "app_exit") {
+                withCategory($0.foregroundExitData, "foreground") {
                     captureMetric(
-                        key: "pixel_luminance_average",
-                        value: averagePixelLuminance.averageMeasurement
+                        key: "abnormal_exit_count",
+                        value: $0.cumulativeAbnormalExitCount
+                    )
+                    captureMetric(
+                        key: "app_watchdog_exit_count",
+                        value: $0.cumulativeAppWatchdogExitCount
+                    )
+                    captureMetric(
+                        key: "bad_access_exit_count",
+                        value: $0.cumulativeBadAccessExitCount
+                    )
+                    captureMetric(
+                        key: "illegal_instruction_exit_count",
+                        value: $0.cumulativeIllegalInstructionExitCount
+                    )
+                    captureMetric(
+                        key: "memory_resource_limit_exit-count",
+                        value: $0.cumulativeMemoryResourceLimitExitCount
+                    )
+                    captureMetric(
+                        key: "normal_app_exit_count",
+                        value: $0.cumulativeNormalAppExitCount
                     )
                 }
-            }
 
-            // Signpost metrics are a little different from the other metrics, since they can have arbitrary names.
-            if let signpostMetrics = payload.signpostMetrics {
-                for signpostMetric in signpostMetrics {
-                    let span = getMetricKitTracer().spanBuilder(spanName: "MXSignpostMetric")
-                        .startSpan()
-                    span.setAttribute(key: "signpost.name", value: signpostMetric.signpostName)
-                    span.setAttribute(
-                        key: "signpost.category",
-                        value: signpostMetric.signpostCategory
+                withCategory($0.backgroundExitData, "background") {
+                    captureMetric(
+                        key: "abnormal_exit_count",
+                        value: $0.cumulativeAbnormalExitCount
                     )
-                    span.setAttribute(key: "signpost.count", value: signpostMetric.totalCount)
-                    if let intervalData = signpostMetric.signpostIntervalData {
-                        if let cpuTime = intervalData.cumulativeCPUTime {
-                            span.setAttribute(
-                                key: "signpost.cpu_time",
-                                value: cpuTime.attributeValue()
-                            )
-                        }
-                        if let memoryAverage = intervalData.averageMemory {
-                            span.setAttribute(
-                                key: "signpost.memory_average",
-                                value: memoryAverage.averageMeasurement.attributeValue()
-                            )
-                        }
-                        if let logicalWriteCount = intervalData.cumulativeLogicalWrites {
-                            span.setAttribute(
-                                key: "signpost.logical_write_count",
-                                value: logicalWriteCount.attributeValue()
-                            )
-                        }
-                        if #available(iOS 15.0, *) {
-                            if let hitchTimeRatio = intervalData.cumulativeHitchTimeRatio {
-                                span.setAttribute(
-                                    key: "signpost.hitch_time_ratio",
-                                    value: hitchTimeRatio.attributeValue()
-                                )
-                            }
-                        }
-                    }
-                    span.end()
+                    captureMetric(
+                        key: "app_watchdog_exit_count",
+                        value: $0.cumulativeAppWatchdogExitCount
+                    )
+                    captureMetric(
+                        key: "bad_access-exit_count",
+                        value: $0.cumulativeBadAccessExitCount
+                    )
+                    captureMetric(
+                        key: "normal_app_exit_count",
+                        value: $0.cumulativeNormalAppExitCount
+                    )
+                    captureMetric(
+                        key: "memory_pressure_exit_count",
+                        value: $0.cumulativeMemoryPressureExitCount
+                    )
+                    captureMetric(
+                        key: "illegal_instruction_exit_count",
+                        value: $0.cumulativeIllegalInstructionExitCount
+                    )
+                    captureMetric(
+                        key: "cpu_resource_limit_exit_count",
+                        value: $0.cumulativeCPUResourceLimitExitCount
+                    )
+                    captureMetric(
+                        key: "memory_resource_limit_exit_count",
+                        value: $0.cumulativeMemoryResourceLimitExitCount
+                    )
+                    captureMetric(
+                        key: "suspended_with_locked_file_exit_count",
+                        value: $0.cumulativeSuspendedWithLockedFileExitCount
+                    )
+                    captureMetric(
+                        key: "background_task_assertion_timeout_exit_count",
+                        value: $0.cumulativeBackgroundTaskAssertionTimeoutExitCount
+                    )
                 }
             }
         }
-    #endif
+        if #available(iOS 14.0, *) {
+            withCategory(payload.animationMetrics, "animation") {
+                captureMetric(key: "scroll_hitch_time_ratio", value: $0.scrollHitchTimeRatio)
+            }
+        }
+        withCategory(payload.applicationTimeMetrics, "app_time") {
+            captureMetric(
+                key: "foreground_time",
+                value: $0.cumulativeForegroundTime
+            )
+            captureMetric(
+                key: "background_time",
+                value: $0.cumulativeBackgroundTime
+            )
+            captureMetric(
+                key: "background_audio_time",
+                value: $0.cumulativeBackgroundAudioTime
+            )
+            captureMetric(
+                key: "background_location_time",
+                value: $0.cumulativeBackgroundLocationTime
+            )
+        }
+        withCategory(payload.cellularConditionMetrics, "cellular_condition") {
+            captureMetric(
+                key: "cellular_condition_time_average",
+                value: $0.histogrammedCellularConditionTime
+            )
+        }
+        withCategory(payload.cpuMetrics, "cpu") {
+            if #available(iOS 14.0, *) {
+                captureMetric(key: "instruction_count", value: $0.cumulativeCPUInstructions)
+            }
+            captureMetric(key: "cpu_time", value: $0.cumulativeCPUTime)
+        }
+        withCategory(payload.gpuMetrics, "gpu") {
+            captureMetric(key: "time", value: $0.cumulativeGPUTime)
+        }
+        withCategory(payload.diskIOMetrics, "diskio") {
+            captureMetric(key: "logical_write_count", value: $0.cumulativeLogicalWrites)
+        }
+        withCategory(payload.memoryMetrics, "memory") {
+            captureMetric(key: "peak_memory_usage", value: $0.peakMemoryUsage)
+            captureMetric(
+                key: "suspended_memory_average",
+                value: $0.averageSuspendedMemory.averageMeasurement
+            )
+        }
+        // Display metrics *only* has pixel luminance, and it's an MXAverage value.
+        withCategory(payload.displayMetrics, "display") {
+            if let averagePixelLuminance = $0.averagePixelLuminance {
+                captureMetric(
+                    key: "pixel_luminance_average",
+                    value: averagePixelLuminance.averageMeasurement
+                )
+            }
+        }
 
-    @available(iOS 14.0, macOS 12.0, *)
+        // Signpost metrics are a little different from the other metrics, since they can have arbitrary names.
+        if let signpostMetrics = payload.signpostMetrics {
+            for signpostMetric in signpostMetrics {
+                let span = getMetricKitTracer().spanBuilder(spanName: "MXSignpostMetric")
+                    .startSpan()
+                span.setAttribute(key: "signpost.name", value: signpostMetric.signpostName)
+                span.setAttribute(
+                    key: "signpost.category",
+                    value: signpostMetric.signpostCategory
+                )
+                span.setAttribute(key: "signpost.count", value: signpostMetric.totalCount)
+                if let intervalData = signpostMetric.signpostIntervalData {
+                    if let cpuTime = intervalData.cumulativeCPUTime {
+                        span.setAttribute(
+                            key: "signpost.cpu_time",
+                            value: cpuTime.attributeValue()
+                        )
+                    }
+                    if let memoryAverage = intervalData.averageMemory {
+                        span.setAttribute(
+                            key: "signpost.memory_average",
+                            value: memoryAverage.averageMeasurement.attributeValue()
+                        )
+                    }
+                    if let logicalWriteCount = intervalData.cumulativeLogicalWrites {
+                        span.setAttribute(
+                            key: "signpost.logical_write_count",
+                            value: logicalWriteCount.attributeValue()
+                        )
+                    }
+                    if #available(iOS 15.0, *) {
+                        if let hitchTimeRatio = intervalData.cumulativeHitchTimeRatio {
+                            span.setAttribute(
+                                key: "signpost.hitch_time_ratio",
+                                value: hitchTimeRatio.attributeValue()
+                            )
+                        }
+                    }
+                }
+                span.end()
+            }
+        }
+    }
+
+    @available(iOS 14.0, *)
     public func reportDiagnostics(payload: MXDiagnosticPayload) {
         let span = getMetricKitTracer().spanBuilder(spanName: "MXDiagnosticPayload")
             .setStartTime(time: payload.timeStampBegin)
@@ -387,15 +383,13 @@
             }
         }
 
-        #if os(iOS)
-            if #available(iOS 16.0, *) {
-                logForEach(payload.appLaunchDiagnostics, "app_launch") {
-                    [
-                        "launch_duration": $0.launchDuration
-                    ]
-                }
+        if #available(iOS 16.0, *) {
+            logForEach(payload.appLaunchDiagnostics, "app_launch") {
+                [
+                    "launch_duration": $0.launchDuration
+                ]
             }
-        #endif
+        }
         logForEach(payload.diskWriteExceptionDiagnostics, "disk_write_exception") {
             [
                 "total_writes_caused": $0.totalWritesCaused
@@ -426,7 +420,7 @@
             if let terminationReason = $0.terminationReason {
                 attrs["exception.termination_reason"] = terminationReason
             }
-            if #available(iOS 17.0, macOS 14.0, *) {
+            if #available(iOS 17.0, *) {
                 if let exceptionReason = $0.exceptionReason {
                     attrs["exception.objc.type"] = exceptionReason.exceptionType
                     attrs["exception.objc.message"] = exceptionReason.composedMessage

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -1,419 +1,440 @@
 #if canImport(MXMetricManager)
-import Foundation
-import MetricKit
-import OpenTelemetryApi
+    import Foundation
+    import MetricKit
+    import OpenTelemetryApi
 
-private let metricKitInstrumentationName = "io.honeycomb.metrickit"
+    private let metricKitInstrumentationName = "io.honeycomb.metrickit"
 
-@available(iOS 13.0, macOS 12.0, *)
-class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
-    #if os(iOS)
-        func didReceive(_ payloads: [MXMetricPayload]) {
+    @available(iOS 13.0, macOS 12.0, *)
+    class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
+        #if os(iOS)
+            func didReceive(_ payloads: [MXMetricPayload]) {
+                for payload in payloads {
+                    reportMetrics(payload: payload)
+                }
+            }
+        #endif
+
+        @available(iOS 14.0, macOS 12.0, *)
+        func didReceive(_ payloads: [MXDiagnosticPayload]) {
             for payload in payloads {
-                reportMetrics(payload: payload)
+                reportDiagnostics(payload: payload)
+            }
+        }
+    }
+
+    // MARK: - MetricKit helpers
+
+    // TODO: Figure out how to set OTel Metrics as well.
+
+    func getMetricKitTracer() -> Tracer {
+        return OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: metricKitInstrumentationName,
+            instrumentationVersion: honeycombLibraryVersion
+        )
+    }
+
+    /// Estimates the average value of the whole histogram.
+    @available(iOS 13.0, macOS 12.0, *)
+    func estimateHistogramAverage<UnitType>(_ histogram: MXHistogram<UnitType>) -> Measurement<
+        UnitType
+    >? {
+        var estimatedSum: Measurement<UnitType>?
+        var sampleCount = 0.0
+        for bucket in histogram.bucketEnumerator {
+            let bucket = bucket as! MXHistogramBucket<UnitType>
+            let estimatedValue = (bucket.bucketStart + bucket.bucketEnd) / 2.0
+            let count = Double(bucket.bucketCount)
+            estimatedSum =
+                if let previousSum = estimatedSum {
+                    previousSum + estimatedValue * count
+                } else {
+                    estimatedValue * count
+                }
+            sampleCount += count
+        }
+        return estimatedSum.map { $0 / sampleCount }
+    }
+
+    #if os(iOS)
+        public func reportMetrics(payload: MXMetricPayload) {
+            let span = getMetricKitTracer().spanBuilder(spanName: "MXMetricPayload")
+                .setStartTime(time: payload.timeStampBegin)
+                .startSpan()
+            defer { span.end(time: payload.timeStampEnd) }
+
+            // There are so many nested metrics we want to capture, it's worth setting up some helper
+            // methods to reduce the amount of repeated code.
+
+            var namespaceStack = ["metrickit"]
+
+            func captureMetric(key: String, value: AttributeValueConvertable) {
+                let namespace = namespaceStack.joined(separator: ".")
+                span.setAttribute(key: "\(namespace).\(key)", value: value.attributeValue())
+            }
+
+            // Helper functions for sending histograms, specifically.
+            func captureMetric<UnitType>(key: String, value histogram: MXHistogram<UnitType>) {
+                if let average = estimateHistogramAverage(histogram) {
+                    captureMetric(key: key, value: average)
+                }
+            }
+
+            // This helper makes it easier to process each category without typing its name repeatedly.
+            func withCategory<T>(_ parent: T?, _ namespace: String, using closure: (T) -> Void) {
+                namespaceStack.append(namespace)
+                if let p = parent {
+                    closure(p)
+                }
+                namespaceStack.removeLast()
+            }
+
+            // These attribute names follow the guidelines at
+            // https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/
+
+            captureMetric(
+                key: "includes_multiple_application_versions",
+                value: payload.includesMultipleApplicationVersions
+            )
+            captureMetric(
+                key: "latest_application_version",
+                value: payload.latestApplicationVersion
+            )
+            captureMetric(
+                key: "timestamp_begin",
+                value: payload.timeStampBegin.timeIntervalSince1970
+            )
+            captureMetric(key: "timestamp_end", value: payload.timeStampEnd.timeIntervalSince1970)
+
+            withCategory(payload.metaData, "metadata") {
+                captureMetric(key: "app_build_version", value: $0.applicationBuildVersion)
+                captureMetric(key: "device_type", value: $0.deviceType)
+                captureMetric(key: "os_version", value: $0.osVersion)
+                captureMetric(key: "region_format", value: $0.regionFormat)
+                if #available(iOS 14.0, *) {
+                    captureMetric(key: "platform_arch", value: $0.platformArchitecture)
+                }
+                if #available(iOS 17.0, *) {
+                    captureMetric(key: "is_test_flight_app", value: $0.isTestFlightApp)
+                    captureMetric(key: "low_power_mode_enabled", value: $0.lowPowerModeEnabled)
+                    captureMetric(key: "pid", value: Int($0.pid))
+                }
+            }
+            withCategory(payload.applicationLaunchMetrics, "app_launch") {
+                captureMetric(
+                    key: "time_to_first_draw_average",
+                    value: $0.histogrammedTimeToFirstDraw
+                )
+                captureMetric(
+                    key: "app_resume_time_average",
+                    value: $0.histogrammedApplicationResumeTime
+                )
+                if #available(iOS 15.2, *) {
+                    captureMetric(
+                        key: "optimized_time_to_first_draw_average",
+                        value: $0.histogrammedOptimizedTimeToFirstDraw
+                    )
+                }
+                if #available(iOS 16.0, *) {
+                    captureMetric(
+                        key: "extended_launch_average",
+                        value: $0.histogrammedExtendedLaunch
+                    )
+                }
+            }
+            withCategory(payload.applicationResponsivenessMetrics, "app_responsiveness") {
+                captureMetric(key: "hang_time_average", value: $0.histogrammedApplicationHangTime)
+            }
+            withCategory(payload.cellularConditionMetrics, "cellular_condition") {
+                captureMetric(key: "bars_average", value: $0.histogrammedCellularConditionTime)
+            }
+            withCategory(payload.locationActivityMetrics, "location_activity") {
+                captureMetric(key: "best_accuracy_time", value: $0.cumulativeBestAccuracyTime)
+                captureMetric(
+                    key: "best_accuracy_for_nav_time",
+                    value: $0.cumulativeBestAccuracyForNavigationTime
+                )
+                captureMetric(
+                    key: "accuracy_10m_time",
+                    value: $0.cumulativeNearestTenMetersAccuracyTime
+                )
+                captureMetric(
+                    key: "accuracy_100m_time",
+                    value: $0.cumulativeHundredMetersAccuracyTime
+                )
+                captureMetric(key: "accuracy_1km_time", value: $0.cumulativeKilometerAccuracyTime)
+                captureMetric(
+                    key: "accuracy_3km_time",
+                    value: $0.cumulativeThreeKilometersAccuracyTime
+                )
+            }
+            withCategory(payload.networkTransferMetrics, "network_transfer") {
+                captureMetric(key: "cellular_download", value: $0.cumulativeCellularDownload)
+                captureMetric(key: "cellular_upload", value: $0.cumulativeCellularUpload)
+                captureMetric(key: "wifi_download", value: $0.cumulativeWifiDownload)
+                captureMetric(key: "wifi_upload", value: $0.cumulativeWifiUpload)
+            }
+            if #available(iOS 14.0, *) {
+                withCategory(payload.applicationExitMetrics, "app_exit") {
+                    withCategory($0.foregroundExitData, "foreground") {
+                        captureMetric(
+                            key: "abnormal_exit_count",
+                            value: $0.cumulativeAbnormalExitCount
+                        )
+                        captureMetric(
+                            key: "app_watchdog_exit_count",
+                            value: $0.cumulativeAppWatchdogExitCount
+                        )
+                        captureMetric(
+                            key: "bad_access_exit_count",
+                            value: $0.cumulativeBadAccessExitCount
+                        )
+                        captureMetric(
+                            key: "illegal_instruction_exit_count",
+                            value: $0.cumulativeIllegalInstructionExitCount
+                        )
+                        captureMetric(
+                            key: "memory_resource_limit_exit-count",
+                            value: $0.cumulativeMemoryResourceLimitExitCount
+                        )
+                        captureMetric(
+                            key: "normal_app_exit_count",
+                            value: $0.cumulativeNormalAppExitCount
+                        )
+                    }
+
+                    withCategory($0.backgroundExitData, "background") {
+                        captureMetric(
+                            key: "abnormal_exit_count",
+                            value: $0.cumulativeAbnormalExitCount
+                        )
+                        captureMetric(
+                            key: "app_watchdog_exit_count",
+                            value: $0.cumulativeAppWatchdogExitCount
+                        )
+                        captureMetric(
+                            key: "bad_access-exit_count",
+                            value: $0.cumulativeBadAccessExitCount
+                        )
+                        captureMetric(
+                            key: "normal_app_exit_count",
+                            value: $0.cumulativeNormalAppExitCount
+                        )
+                        captureMetric(
+                            key: "memory_pressure_exit_count",
+                            value: $0.cumulativeMemoryPressureExitCount
+                        )
+                        captureMetric(
+                            key: "illegal_instruction_exit_count",
+                            value: $0.cumulativeIllegalInstructionExitCount
+                        )
+                        captureMetric(
+                            key: "cpu_resource_limit_exit_count",
+                            value: $0.cumulativeCPUResourceLimitExitCount
+                        )
+                        captureMetric(
+                            key: "memory_resource_limit_exit_count",
+                            value: $0.cumulativeMemoryResourceLimitExitCount
+                        )
+                        captureMetric(
+                            key: "suspended_with_locked_file_exit_count",
+                            value: $0.cumulativeSuspendedWithLockedFileExitCount
+                        )
+                        captureMetric(
+                            key: "background_task_assertion_timeout_exit_count",
+                            value: $0.cumulativeBackgroundTaskAssertionTimeoutExitCount
+                        )
+                    }
+                }
+            }
+            if #available(iOS 14.0, *) {
+                withCategory(payload.animationMetrics, "animation") {
+                    captureMetric(key: "scroll_hitch_time_ratio", value: $0.scrollHitchTimeRatio)
+                }
+            }
+            withCategory(payload.applicationTimeMetrics, "app_time") {
+                captureMetric(
+                    key: "foreground_time",
+                    value: $0.cumulativeForegroundTime
+                )
+                captureMetric(
+                    key: "background_time",
+                    value: $0.cumulativeBackgroundTime
+                )
+                captureMetric(
+                    key: "background_audio_time",
+                    value: $0.cumulativeBackgroundAudioTime
+                )
+                captureMetric(
+                    key: "background_location_time",
+                    value: $0.cumulativeBackgroundLocationTime
+                )
+            }
+            withCategory(payload.cellularConditionMetrics, "cellular_condition") {
+                captureMetric(
+                    key: "cellular_condition_time_average",
+                    value: $0.histogrammedCellularConditionTime
+                )
+            }
+            withCategory(payload.cpuMetrics, "cpu") {
+                if #available(iOS 14.0, *) {
+                    captureMetric(key: "instruction_count", value: $0.cumulativeCPUInstructions)
+                }
+                captureMetric(key: "cpu_time", value: $0.cumulativeCPUTime)
+            }
+            withCategory(payload.gpuMetrics, "gpu") {
+                captureMetric(key: "time", value: $0.cumulativeGPUTime)
+            }
+            withCategory(payload.diskIOMetrics, "diskio") {
+                captureMetric(key: "logical_write_count", value: $0.cumulativeLogicalWrites)
+            }
+            withCategory(payload.memoryMetrics, "memory") {
+                captureMetric(key: "peak_memory_usage", value: $0.peakMemoryUsage)
+                captureMetric(
+                    key: "suspended_memory_average",
+                    value: $0.averageSuspendedMemory.averageMeasurement
+                )
+            }
+            // Display metrics *only* has pixel luminance, and it's an MXAverage value.
+            withCategory(payload.displayMetrics, "display") {
+                if let averagePixelLuminance = $0.averagePixelLuminance {
+                    captureMetric(
+                        key: "pixel_luminance_average",
+                        value: averagePixelLuminance.averageMeasurement
+                    )
+                }
+            }
+
+            // Signpost metrics are a little different from the other metrics, since they can have arbitrary names.
+            if let signpostMetrics = payload.signpostMetrics {
+                for signpostMetric in signpostMetrics {
+                    let span = getMetricKitTracer().spanBuilder(spanName: "MXSignpostMetric")
+                        .startSpan()
+                    span.setAttribute(key: "signpost.name", value: signpostMetric.signpostName)
+                    span.setAttribute(
+                        key: "signpost.category",
+                        value: signpostMetric.signpostCategory
+                    )
+                    span.setAttribute(key: "signpost.count", value: signpostMetric.totalCount)
+                    if let intervalData = signpostMetric.signpostIntervalData {
+                        if let cpuTime = intervalData.cumulativeCPUTime {
+                            span.setAttribute(
+                                key: "signpost.cpu_time",
+                                value: cpuTime.attributeValue()
+                            )
+                        }
+                        if let memoryAverage = intervalData.averageMemory {
+                            span.setAttribute(
+                                key: "signpost.memory_average",
+                                value: memoryAverage.averageMeasurement.attributeValue()
+                            )
+                        }
+                        if let logicalWriteCount = intervalData.cumulativeLogicalWrites {
+                            span.setAttribute(
+                                key: "signpost.logical_write_count",
+                                value: logicalWriteCount.attributeValue()
+                            )
+                        }
+                        if #available(iOS 15.0, *) {
+                            if let hitchTimeRatio = intervalData.cumulativeHitchTimeRatio {
+                                span.setAttribute(
+                                    key: "signpost.hitch_time_ratio",
+                                    value: hitchTimeRatio.attributeValue()
+                                )
+                            }
+                        }
+                    }
+                    span.end()
+                }
             }
         }
     #endif
 
     @available(iOS 14.0, macOS 12.0, *)
-    func didReceive(_ payloads: [MXDiagnosticPayload]) {
-        for payload in payloads {
-            reportDiagnostics(payload: payload)
-        }
-    }
-}
-
-// MARK: - MetricKit helpers
-
-// TODO: Figure out how to set OTel Metrics as well.
-
-func getMetricKitTracer() -> Tracer {
-    return OpenTelemetry.instance.tracerProvider.get(
-        instrumentationName: metricKitInstrumentationName,
-        instrumentationVersion: honeycombLibraryVersion
-    )
-}
-
-/// Estimates the average value of the whole histogram.
-@available(iOS 13.0, macOS 12.0, *)
-func estimateHistogramAverage<UnitType>(_ histogram: MXHistogram<UnitType>) -> Measurement<
-    UnitType
->? {
-    var estimatedSum: Measurement<UnitType>?
-    var sampleCount = 0.0
-    for bucket in histogram.bucketEnumerator {
-        let bucket = bucket as! MXHistogramBucket<UnitType>
-        let estimatedValue = (bucket.bucketStart + bucket.bucketEnd) / 2.0
-        let count = Double(bucket.bucketCount)
-        estimatedSum =
-            if let previousSum = estimatedSum {
-                previousSum + estimatedValue * count
-            } else {
-                estimatedValue * count
-            }
-        sampleCount += count
-    }
-    return estimatedSum.map { $0 / sampleCount }
-}
-
-#if os(iOS)
-    public func reportMetrics(payload: MXMetricPayload) {
-        let span = getMetricKitTracer().spanBuilder(spanName: "MXMetricPayload")
+    public func reportDiagnostics(payload: MXDiagnosticPayload) {
+        let span = getMetricKitTracer().spanBuilder(spanName: "MXDiagnosticPayload")
             .setStartTime(time: payload.timeStampBegin)
             .startSpan()
-        defer { span.end(time: payload.timeStampEnd) }
+        defer { span.end() }
 
-        // There are so many nested metrics we want to capture, it's worth setting up some helper
-        // methods to reduce the amount of repeated code.
-
-        var namespaceStack = ["metrickit"]
-
-        func captureMetric(key: String, value: AttributeValueConvertable) {
-            let namespace = namespaceStack.joined(separator: ".")
-            span.setAttribute(key: "\(namespace).\(key)", value: value.attributeValue())
-        }
-
-        // Helper functions for sending histograms, specifically.
-        func captureMetric<UnitType>(key: String, value histogram: MXHistogram<UnitType>) {
-            if let average = estimateHistogramAverage(histogram) {
-                captureMetric(key: key, value: average)
-            }
-        }
-
-        // This helper makes it easier to process each category without typing its name repeatedly.
-        func withCategory<T>(_ parent: T?, _ namespace: String, using closure: (T) -> Void) {
-            namespaceStack.append(namespace)
-            if let p = parent {
-                closure(p)
-            }
-            namespaceStack.removeLast()
-        }
-
-        // These attribute names follow the guidelines at
-        // https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/
-
-        captureMetric(
-            key: "includes_multiple_application_versions",
-            value: payload.includesMultipleApplicationVersions
+        let logger = OpenTelemetry.instance.loggerProvider.get(
+            instrumentationScopeName: metricKitInstrumentationName
         )
-        captureMetric(key: "latest_application_version", value: payload.latestApplicationVersion)
-        captureMetric(key: "timestamp_begin", value: payload.timeStampBegin.timeIntervalSince1970)
-        captureMetric(key: "timestamp_end", value: payload.timeStampEnd.timeIntervalSince1970)
 
-        withCategory(payload.metaData, "metadata") {
-            captureMetric(key: "app_build_version", value: $0.applicationBuildVersion)
-            captureMetric(key: "device_type", value: $0.deviceType)
-            captureMetric(key: "os_version", value: $0.osVersion)
-            captureMetric(key: "region_format", value: $0.regionFormat)
-            if #available(iOS 14.0, *) {
-                captureMetric(key: "platform_arch", value: $0.platformArchitecture)
-            }
-            if #available(iOS 17.0, *) {
-                captureMetric(key: "is_test_flight_app", value: $0.isTestFlightApp)
-                captureMetric(key: "low_power_mode_enabled", value: $0.lowPowerModeEnabled)
-                captureMetric(key: "pid", value: Int($0.pid))
+        let now = Date()
+
+        // A helper for looping over the items in an optional list and logging each one.
+        func logForEach<T>(
+            _ parent: [T]?,
+            _ namespace: String,
+            using closure: (T) -> [String: AttributeValueConvertable]
+        ) {
+            if let arr = parent {
+                for item in arr {
+                    var attributes: [String: AttributeValue] = [
+                        "name": "metrickit.diagnostic.\(namespace)".attributeValue()
+                    ]
+                    for (key, value) in closure(item) {
+                        let namespacedKey = "metrickit.diagnostic.\(namespace).\(key)"
+                        attributes[namespacedKey] = value.attributeValue()
+                    }
+                    logger.logRecordBuilder()
+                        .setTimestamp(payload.timeStampEnd)
+                        .setObservedTimestamp(now)
+                        .setAttributes(attributes)
+                        .emit()
+                }
             }
         }
-        withCategory(payload.applicationLaunchMetrics, "app_launch") {
-            captureMetric(key: "time_to_first_draw_average", value: $0.histogrammedTimeToFirstDraw)
-            captureMetric(
-                key: "app_resume_time_average",
-                value: $0.histogrammedApplicationResumeTime
-            )
-            if #available(iOS 15.2, *) {
-                captureMetric(
-                    key: "optimized_time_to_first_draw_average",
-                    value: $0.histogrammedOptimizedTimeToFirstDraw
-                )
-            }
+
+        #if os(iOS)
             if #available(iOS 16.0, *) {
-                captureMetric(key: "extended_launch_average", value: $0.histogrammedExtendedLaunch)
-            }
-        }
-        withCategory(payload.applicationResponsivenessMetrics, "app_responsiveness") {
-            captureMetric(key: "hang_time_average", value: $0.histogrammedApplicationHangTime)
-        }
-        withCategory(payload.cellularConditionMetrics, "cellular_condition") {
-            captureMetric(key: "bars_average", value: $0.histogrammedCellularConditionTime)
-        }
-        withCategory(payload.locationActivityMetrics, "location_activity") {
-            captureMetric(key: "best_accuracy_time", value: $0.cumulativeBestAccuracyTime)
-            captureMetric(
-                key: "best_accuracy_for_nav_time",
-                value: $0.cumulativeBestAccuracyForNavigationTime
-            )
-            captureMetric(
-                key: "accuracy_10m_time",
-                value: $0.cumulativeNearestTenMetersAccuracyTime
-            )
-            captureMetric(key: "accuracy_100m_time", value: $0.cumulativeHundredMetersAccuracyTime)
-            captureMetric(key: "accuracy_1km_time", value: $0.cumulativeKilometerAccuracyTime)
-            captureMetric(key: "accuracy_3km_time", value: $0.cumulativeThreeKilometersAccuracyTime)
-        }
-        withCategory(payload.networkTransferMetrics, "network_transfer") {
-            captureMetric(key: "cellular_download", value: $0.cumulativeCellularDownload)
-            captureMetric(key: "cellular_upload", value: $0.cumulativeCellularUpload)
-            captureMetric(key: "wifi_download", value: $0.cumulativeWifiDownload)
-            captureMetric(key: "wifi_upload", value: $0.cumulativeWifiUpload)
-        }
-        if #available(iOS 14.0, *) {
-            withCategory(payload.applicationExitMetrics, "app_exit") {
-                withCategory($0.foregroundExitData, "foreground") {
-                    captureMetric(
-                        key: "abnormal_exit_count",
-                        value: $0.cumulativeAbnormalExitCount
-                    )
-                    captureMetric(
-                        key: "app_watchdog_exit_count",
-                        value: $0.cumulativeAppWatchdogExitCount
-                    )
-                    captureMetric(
-                        key: "bad_access_exit_count",
-                        value: $0.cumulativeBadAccessExitCount
-                    )
-                    captureMetric(
-                        key: "illegal_instruction_exit_count",
-                        value: $0.cumulativeIllegalInstructionExitCount
-                    )
-                    captureMetric(
-                        key: "memory_resource_limit_exit-count",
-                        value: $0.cumulativeMemoryResourceLimitExitCount
-                    )
-                    captureMetric(
-                        key: "normal_app_exit_count",
-                        value: $0.cumulativeNormalAppExitCount
-                    )
-                }
-
-                withCategory($0.backgroundExitData, "background") {
-                    captureMetric(
-                        key: "abnormal_exit_count",
-                        value: $0.cumulativeAbnormalExitCount
-                    )
-                    captureMetric(
-                        key: "app_watchdog_exit_count",
-                        value: $0.cumulativeAppWatchdogExitCount
-                    )
-                    captureMetric(
-                        key: "bad_access-exit_count",
-                        value: $0.cumulativeBadAccessExitCount
-                    )
-                    captureMetric(
-                        key: "normal_app_exit_count",
-                        value: $0.cumulativeNormalAppExitCount
-                    )
-                    captureMetric(
-                        key: "memory_pressure_exit_count",
-                        value: $0.cumulativeMemoryPressureExitCount
-                    )
-                    captureMetric(
-                        key: "illegal_instruction_exit_count",
-                        value: $0.cumulativeIllegalInstructionExitCount
-                    )
-                    captureMetric(
-                        key: "cpu_resource_limit_exit_count",
-                        value: $0.cumulativeCPUResourceLimitExitCount
-                    )
-                    captureMetric(
-                        key: "memory_resource_limit_exit_count",
-                        value: $0.cumulativeMemoryResourceLimitExitCount
-                    )
-                    captureMetric(
-                        key: "suspended_with_locked_file_exit_count",
-                        value: $0.cumulativeSuspendedWithLockedFileExitCount
-                    )
-                    captureMetric(
-                        key: "background_task_assertion_timeout_exit_count",
-                        value: $0.cumulativeBackgroundTaskAssertionTimeoutExitCount
-                    )
+                logForEach(payload.appLaunchDiagnostics, "app_launch") {
+                    [
+                        "launch_duration": $0.launchDuration
+                    ]
                 }
             }
+        #endif
+        logForEach(payload.diskWriteExceptionDiagnostics, "disk_write_exception") {
+            [
+                "total_writes_caused": $0.totalWritesCaused
+            ]
         }
-        if #available(iOS 14.0, *) {
-            withCategory(payload.animationMetrics, "animation") {
-                captureMetric(key: "scroll_hitch_time_ratio", value: $0.scrollHitchTimeRatio)
+        logForEach(payload.hangDiagnostics, "hang") {
+            [
+                "hang_duration": $0.hangDuration
+            ]
+        }
+        logForEach(payload.cpuExceptionDiagnostics, "cpu_exception") {
+            [
+                "total_cpu_time": $0.totalCPUTime,
+                "total_sampled_time": $0.totalSampledTime,
+            ]
+        }
+        logForEach(payload.crashDiagnostics, "crash") {
+            var attrs: [String: AttributeValueConvertable] = [:]
+            if let exceptionCode = $0.exceptionCode {
+                attrs["exception.code"] = exceptionCode.intValue
             }
-        }
-        withCategory(payload.applicationTimeMetrics, "app_time") {
-            captureMetric(
-                key: "foreground_time",
-                value: $0.cumulativeForegroundTime
-            )
-            captureMetric(
-                key: "background_time",
-                value: $0.cumulativeBackgroundTime
-            )
-            captureMetric(
-                key: "background_audio_time",
-                value: $0.cumulativeBackgroundAudioTime
-            )
-            captureMetric(
-                key: "background_location_time",
-                value: $0.cumulativeBackgroundLocationTime
-            )
-        }
-        withCategory(payload.cellularConditionMetrics, "cellular_condition") {
-            captureMetric(
-                key: "cellular_condition_time_average",
-                value: $0.histogrammedCellularConditionTime
-            )
-        }
-        withCategory(payload.cpuMetrics, "cpu") {
-            if #available(iOS 14.0, *) {
-                captureMetric(key: "instruction_count", value: $0.cumulativeCPUInstructions)
+            if let exceptionType = $0.exceptionType {
+                attrs["exception.mach_execution_type"] = exceptionType.intValue
             }
-            captureMetric(key: "cpu_time", value: $0.cumulativeCPUTime)
-        }
-        withCategory(payload.gpuMetrics, "gpu") {
-            captureMetric(key: "time", value: $0.cumulativeGPUTime)
-        }
-        withCategory(payload.diskIOMetrics, "diskio") {
-            captureMetric(key: "logical_write_count", value: $0.cumulativeLogicalWrites)
-        }
-        withCategory(payload.memoryMetrics, "memory") {
-            captureMetric(key: "peak_memory_usage", value: $0.peakMemoryUsage)
-            captureMetric(
-                key: "suspended_memory_average",
-                value: $0.averageSuspendedMemory.averageMeasurement
-            )
-        }
-        // Display metrics *only* has pixel luminance, and it's an MXAverage value.
-        withCategory(payload.displayMetrics, "display") {
-            if let averagePixelLuminance = $0.averagePixelLuminance {
-                captureMetric(
-                    key: "pixel_luminance_average",
-                    value: averagePixelLuminance.averageMeasurement
-                )
+            if let signal = $0.signal {
+                attrs["exception.signal"] = signal.intValue
             }
-        }
-
-        // Signpost metrics are a little different from the other metrics, since they can have arbitrary names.
-        if let signpostMetrics = payload.signpostMetrics {
-            for signpostMetric in signpostMetrics {
-                let span = getMetricKitTracer().spanBuilder(spanName: "MXSignpostMetric")
-                    .startSpan()
-                span.setAttribute(key: "signpost.name", value: signpostMetric.signpostName)
-                span.setAttribute(key: "signpost.category", value: signpostMetric.signpostCategory)
-                span.setAttribute(key: "signpost.count", value: signpostMetric.totalCount)
-                if let intervalData = signpostMetric.signpostIntervalData {
-                    if let cpuTime = intervalData.cumulativeCPUTime {
-                        span.setAttribute(
-                            key: "signpost.cpu_time",
-                            value: cpuTime.attributeValue()
-                        )
-                    }
-                    if let memoryAverage = intervalData.averageMemory {
-                        span.setAttribute(
-                            key: "signpost.memory_average",
-                            value: memoryAverage.averageMeasurement.attributeValue()
-                        )
-                    }
-                    if let logicalWriteCount = intervalData.cumulativeLogicalWrites {
-                        span.setAttribute(
-                            key: "signpost.logical_write_count",
-                            value: logicalWriteCount.attributeValue()
-                        )
-                    }
-                    if #available(iOS 15.0, *) {
-                        if let hitchTimeRatio = intervalData.cumulativeHitchTimeRatio {
-                            span.setAttribute(
-                                key: "signpost.hitch_time_ratio",
-                                value: hitchTimeRatio.attributeValue()
-                            )
-                        }
-                    }
+            if let terminationReason = $0.terminationReason {
+                attrs["exception.termination_reason"] = terminationReason
+            }
+            if #available(iOS 17.0, macOS 14.0, *) {
+                if let exceptionReason = $0.exceptionReason {
+                    attrs["exception.objc.type"] = exceptionReason.exceptionType
+                    attrs["exception.objc.message"] = exceptionReason.composedMessage
+                    attrs["exception.objc.classname"] = exceptionReason.className
+                    attrs["exception.objc.name"] = exceptionReason.exceptionName
                 }
-                span.end()
             }
+            return attrs
         }
     }
-#endif
-
-@available(iOS 14.0, macOS 12.0, *)
-public func reportDiagnostics(payload: MXDiagnosticPayload) {
-    let span = getMetricKitTracer().spanBuilder(spanName: "MXDiagnosticPayload")
-        .setStartTime(time: payload.timeStampBegin)
-        .startSpan()
-    defer { span.end() }
-
-    let logger = OpenTelemetry.instance.loggerProvider.get(
-        instrumentationScopeName: metricKitInstrumentationName
-    )
-
-    let now = Date()
-
-    // A helper for looping over the items in an optional list and logging each one.
-    func logForEach<T>(
-        _ parent: [T]?,
-        _ namespace: String,
-        using closure: (T) -> [String: AttributeValueConvertable]
-    ) {
-        if let arr = parent {
-            for item in arr {
-                var attributes: [String: AttributeValue] = [
-                    "name": "metrickit.diagnostic.\(namespace)".attributeValue()
-                ]
-                for (key, value) in closure(item) {
-                    let namespacedKey = "metrickit.diagnostic.\(namespace).\(key)"
-                    attributes[namespacedKey] = value.attributeValue()
-                }
-                logger.logRecordBuilder()
-                    .setTimestamp(payload.timeStampEnd)
-                    .setObservedTimestamp(now)
-                    .setAttributes(attributes)
-                    .emit()
-            }
-        }
-    }
-
-    #if os(iOS)
-        if #available(iOS 16.0, *) {
-            logForEach(payload.appLaunchDiagnostics, "app_launch") {
-                [
-                    "launch_duration": $0.launchDuration
-                ]
-            }
-        }
-    #endif
-    logForEach(payload.diskWriteExceptionDiagnostics, "disk_write_exception") {
-        [
-            "total_writes_caused": $0.totalWritesCaused
-        ]
-    }
-    logForEach(payload.hangDiagnostics, "hang") {
-        [
-            "hang_duration": $0.hangDuration
-        ]
-    }
-    logForEach(payload.cpuExceptionDiagnostics, "cpu_exception") {
-        [
-            "total_cpu_time": $0.totalCPUTime,
-            "total_sampled_time": $0.totalSampledTime,
-        ]
-    }
-    logForEach(payload.crashDiagnostics, "crash") {
-        var attrs: [String: AttributeValueConvertable] = [:]
-        if let exceptionCode = $0.exceptionCode {
-            attrs["exception.code"] = exceptionCode.intValue
-        }
-        if let exceptionType = $0.exceptionType {
-            attrs["exception.mach_execution_type"] = exceptionType.intValue
-        }
-        if let signal = $0.signal {
-            attrs["exception.signal"] = signal.intValue
-        }
-        if let terminationReason = $0.terminationReason {
-            attrs["exception.termination_reason"] = terminationReason
-        }
-        if #available(iOS 17.0, macOS 14.0, *) {
-            if let exceptionReason = $0.exceptionReason {
-                attrs["exception.objc.type"] = exceptionReason.exceptionType
-                attrs["exception.objc.message"] = exceptionReason.composedMessage
-                attrs["exception.objc.classname"] = exceptionReason.className
-                attrs["exception.objc.name"] = exceptionReason.exceptionName
-            }
-        }
-        return attrs
-    }
-}
 #endif

--- a/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
+++ b/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
@@ -1,3 +1,4 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
 import Foundation
 import NetworkStatus
 import OpenTelemetryApi
@@ -28,3 +29,4 @@ public struct NetworkStatusSpanProcessor: SpanProcessor {
 
     public func forceFlush(timeout: TimeInterval? = nil) {}
 }
+#endif

--- a/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
+++ b/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
@@ -1,32 +1,32 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
-import Foundation
-import NetworkStatus
-import OpenTelemetryApi
-import OpenTelemetrySdk
+    import Foundation
+    import NetworkStatus
+    import OpenTelemetryApi
+    import OpenTelemetrySdk
 
-public struct NetworkStatusSpanProcessor: SpanProcessor {
-    public let isStartRequired = true
-    public let isEndRequired = false
+    public struct NetworkStatusSpanProcessor: SpanProcessor {
+        public let isStartRequired = true
+        public let isEndRequired = false
 
-    private let networkMonitor: NetworkMonitor
+        private let networkMonitor: NetworkMonitor
 
-    init(monitor: NetworkMonitor) {
-        networkMonitor = monitor
+        init(monitor: NetworkMonitor) {
+            networkMonitor = monitor
+        }
+
+        public func onStart(
+            parentContext: SpanContext?,
+            span: any ReadableSpan
+        ) {
+            let status = NetworkStatus(with: networkMonitor)
+            let injector = NetworkStatusInjector(netstat: status)
+            injector.inject(span: span)
+        }
+
+        public func onEnd(span: any ReadableSpan) {}
+
+        public func shutdown(explicitTimeout: TimeInterval? = nil) {}
+
+        public func forceFlush(timeout: TimeInterval? = nil) {}
     }
-
-    public func onStart(
-        parentContext: SpanContext?,
-        span: any ReadableSpan
-    ) {
-        let status = NetworkStatus(with: networkMonitor)
-        let injector = NetworkStatusInjector(netstat: status)
-        injector.inject(span: span)
-    }
-
-    public func onEnd(span: any ReadableSpan) {}
-
-    public func shutdown(explicitTimeout: TimeInterval? = nil) {}
-
-    public func forceFlush(timeout: TimeInterval? = nil) {}
-}
 #endif

--- a/Sources/Honeycomb/Networking/URLSessionTask.swift
+++ b/Sources/Honeycomb/Networking/URLSessionTask.swift
@@ -26,7 +26,7 @@ extension URLSessionTask {
                 ProxyURLSessionTaskDelegate.setSpan(span, for: self)
 
                 // In iOS 15+, it's possible to set a delegate for the task that overrides the delegate for the session.
-                if #available(iOS 15, macOS 12, *) {
+                if #available(tvOS 16.0, iOS 15, macOS 12, *) {
                     if self.delegate != nil {
                         self.delegate = ProxyURLSessionTaskDelegate(self.delegate)
                     }

--- a/Sources/Honeycomb/Networking/URLSessionTask.swift
+++ b/Sources/Honeycomb/Networking/URLSessionTask.swift
@@ -26,7 +26,7 @@ extension URLSessionTask {
                 ProxyURLSessionTaskDelegate.setSpan(span, for: self)
 
                 // In iOS 15+, it's possible to set a delegate for the task that overrides the delegate for the session.
-                if #available(tvOS 16.0, iOS 15, macOS 12, *) {
+                if #available(tvOS 16.0, iOS 15, macOS 12, watchOS 8, *) {
                     if self.delegate != nil {
                         self.delegate = ProxyURLSessionTaskDelegate(self.delegate)
                     }

--- a/Sources/Honeycomb/UIDeviceSpanProcessor.swift
+++ b/Sources/Honeycomb/UIDeviceSpanProcessor.swift
@@ -27,8 +27,9 @@
                 key: "device.isMultitaskingSupported",
                 value: device.isMultitaskingSupported
             )
+            
+            #if os(iOS)
             span.setAttribute(key: "device.orientation", value: device.orientation.description)
-
             span.setAttribute(
                 key: "device.isBatteryMonitoringEnabled",
                 value: device.isBatteryMonitoringEnabled
@@ -44,6 +45,7 @@
                     value: device.batteryState.description
                 )
             }
+            #endif
 
             span.setAttribute(
                 key: "device.isLowPowerModeEnabled",
@@ -58,6 +60,7 @@
         public func forceFlush(timeout: TimeInterval? = nil) {}
     }
 
+#if os(iOS)
     extension UIDeviceOrientation {
         fileprivate var description: String {
             switch self {
@@ -90,6 +93,7 @@
             }
         }
     }
+#endif
 
     extension UIUserInterfaceIdiom {
         fileprivate var description: String {

--- a/Sources/Honeycomb/UIDeviceSpanProcessor.swift
+++ b/Sources/Honeycomb/UIDeviceSpanProcessor.swift
@@ -28,7 +28,7 @@
                 value: device.isMultitaskingSupported
             )
 
-            #if os(iOS)
+            #if !os(tvOS)
                 span.setAttribute(key: "device.orientation", value: device.orientation.description)
                 span.setAttribute(
                     key: "device.isBatteryMonitoringEnabled",
@@ -60,7 +60,7 @@
         public func forceFlush(timeout: TimeInterval? = nil) {}
     }
 
-    #if os(iOS)
+    #if !os(tvOS)
         extension UIDeviceOrientation {
             fileprivate var description: String {
                 switch self {

--- a/Sources/Honeycomb/UIDeviceSpanProcessor.swift
+++ b/Sources/Honeycomb/UIDeviceSpanProcessor.swift
@@ -13,7 +13,7 @@
             span: any ReadableSpan
         ) {
             let device = UIDevice.current
-            
+
             span.setAttribute(key: "device.name", value: device.name)
             span.setAttribute(key: "device.systemName", value: device.systemName)
             span.setAttribute(key: "device.systemVersion", value: device.systemVersion)
@@ -27,24 +27,24 @@
                 key: "device.isMultitaskingSupported",
                 value: device.isMultitaskingSupported
             )
-            
-            #if os(iOS)
-            span.setAttribute(key: "device.orientation", value: device.orientation.description)
-            span.setAttribute(
-                key: "device.isBatteryMonitoringEnabled",
-                value: device.isBatteryMonitoringEnabled
-            )
 
-            if device.isBatteryMonitoringEnabled {
+            #if os(iOS)
+                span.setAttribute(key: "device.orientation", value: device.orientation.description)
                 span.setAttribute(
-                    key: "device.batteryLevel",
-                    value: String(describing: device.batteryLevel)
+                    key: "device.isBatteryMonitoringEnabled",
+                    value: device.isBatteryMonitoringEnabled
                 )
-                span.setAttribute(
-                    key: "device.batteryState",
-                    value: device.batteryState.description
-                )
-            }
+
+                if device.isBatteryMonitoringEnabled {
+                    span.setAttribute(
+                        key: "device.batteryLevel",
+                        value: String(describing: device.batteryLevel)
+                    )
+                    span.setAttribute(
+                        key: "device.batteryState",
+                        value: device.batteryState.description
+                    )
+                }
             #endif
 
             span.setAttribute(
@@ -60,40 +60,40 @@
         public func forceFlush(timeout: TimeInterval? = nil) {}
     }
 
-#if os(iOS)
-    extension UIDeviceOrientation {
-        fileprivate var description: String {
-            switch self {
-            case .faceUp: return "faceUp"
-            case .faceDown: return "faceDown"
-            case .landscapeLeft: return "landscapeLeft"
-            case .landscapeRight: return "landscapeRight"
-            case .portrait: return "portrait"
-            case .portraitUpsideDown: return "portraitUpsideDown"
-            case .unknown: return "unknown"
-            @unknown default:
-                return "unknown"
+    #if os(iOS)
+        extension UIDeviceOrientation {
+            fileprivate var description: String {
+                switch self {
+                case .faceUp: return "faceUp"
+                case .faceDown: return "faceDown"
+                case .landscapeLeft: return "landscapeLeft"
+                case .landscapeRight: return "landscapeRight"
+                case .portrait: return "portrait"
+                case .portraitUpsideDown: return "portraitUpsideDown"
+                case .unknown: return "unknown"
+                @unknown default:
+                    return "unknown"
+                }
             }
         }
-    }
 
-    extension UIDevice.BatteryState {
-        fileprivate var description: String {
-            switch self {
-            case .unknown:
-                return "unknown"
-            case .unplugged:
-                return "unplugged"
-            case .charging:
-                return "charging"
-            case .full:
-                return "full"
-            @unknown default:
-                return "unknown"
+        extension UIDevice.BatteryState {
+            fileprivate var description: String {
+                switch self {
+                case .unknown:
+                    return "unknown"
+                case .unplugged:
+                    return "unplugged"
+                case .charging:
+                    return "charging"
+                case .full:
+                    return "full"
+                @unknown default:
+                    return "unknown"
+                }
             }
         }
-    }
-#endif
+    #endif
 
     extension UIUserInterfaceIdiom {
         fileprivate var description: String {

--- a/Sources/Honeycomb/UIDeviceSpanProcessor.swift
+++ b/Sources/Honeycomb/UIDeviceSpanProcessor.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
     import Foundation
     import OpenTelemetryApi
     import OpenTelemetrySdk
@@ -13,7 +13,7 @@
             span: any ReadableSpan
         ) {
             let device = UIDevice.current
-
+            
             span.setAttribute(key: "device.name", value: device.name)
             span.setAttribute(key: "device.systemName", value: device.systemName)
             span.setAttribute(key: "device.systemVersion", value: device.systemVersion)

--- a/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/NavigationInstrumentation.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
     import Foundation
     import OpenTelemetryApi
     import UIKit

--- a/Sources/Honeycomb/UIKit/UIViewController.swift
+++ b/Sources/Honeycomb/UIKit/UIViewController.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
     import Foundation
     import OpenTelemetryApi
     import UIKit

--- a/Sources/Honeycomb/UIKit/ViewAttributes.swift
+++ b/Sources/Honeycomb/UIKit/ViewAttributes.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
     import Foundation
     import OpenTelemetryApi
     import SwiftUI

--- a/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
+++ b/Sources/Honeycomb/UIKit/WindowInstrumentation.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
     import Foundation
     import OpenTelemetryApi
     import SwiftUI


### PR DESCRIPTION
## Which problem is this PR solving?

We declare in our `package.swift` file that we support the following platforms:

```
    platforms: [
        .macOS(.v12),
        .iOS(.v13),
        .tvOS(.v13),
        .watchOS(.v6),
    ],
```

But we don't actually run any of our CI for these. We don't actually compile on all of these platforms.

## Short description of the changes

Added CI to at least compile the SDK on each of the platforms that we say we support

Added a bunch of hacky conditional compilation statements so that build passes. It's possible we can structure some of the code better to make these a little less unweildly. This will at least put us on the right path of supporting all the platforms we say we do.

We will probably want to update the readme to specify which platforms support which things

## How to verify that this has the expected result

Build passes
