### PR TITLE
fix: navigation instrumentation no longer serializes path as empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+### Fixes
+* NavigationStack root paths now get serialized as `/` instead of `[]`, even when using NavigationPath.
+* Ensure navigation instrumention passes `prefix` param correctly.
+
 ## 0.0.7
 
 ### New Features

--- a/Examples/SmokeTest/SmokeTest/NavigationExamplesView.swift
+++ b/Examples/SmokeTest/SmokeTest/NavigationExamplesView.swift
@@ -61,7 +61,7 @@ struct TreeDetails: View {
 }
 
 struct NavigationStackExample: View {
-    @State private var presentedParks: [Park] = []
+    @State private var presentedParks = NavigationPath()
     @State private var usePrefix = false
 
     var body: some View {

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -40,12 +40,12 @@ internal class HoneycombNavigationProcessor {
             let decodedPath = try! JSONDecoder().decode([String].self, from: encodedPath)
             reportNavigation(prefix: prefix, path: decodedPath, reason: reason)
         } else {
-            reportNavigation(path: unencodablePath, reason: reason)
+            reportNavigation(prefix: prefix, path: unencodablePath, reason: reason)
         }
     }
 
     func reportNavigation(prefix: String? = nil, path: String, reason: String? = nil) {
-        reportNavigation(path: [path], reason: reason)
+        reportNavigation(prefix: prefix, path: [path], reason: reason)
     }
 
     func reportNavigation(prefix: String? = nil, path: Encodable, reason: String? = nil) {
@@ -54,9 +54,9 @@ internal class HoneycombNavigationProcessor {
             let data = try encoder.encode(path)
             let pathStr = String(decoding: data, as: UTF8.self)
 
-            reportNavigation(path: pathStr, reason: reason)
+            reportNavigation(prefix: prefix, path: pathStr, reason: reason)
         } catch {
-            reportNavigation(path: unencodablePath, reason: reason)
+            reportNavigation(prefix: prefix, path: unencodablePath, reason: reason)
         }
     }
 

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -36,9 +36,13 @@ internal class HoneycombNavigationProcessor {
             // the class name and then the actual object
             // but since this is an entirely undocumented internal structure, we're not going to make any assumptions there
             // and will just encode the full path as we get it
-            let encodedPath = try! JSONEncoder().encode(codablePath)
-            let decodedPath = try! JSONDecoder().decode([String].self, from: encodedPath)
-            reportNavigation(prefix: prefix, path: decodedPath, reason: reason)
+            do {
+                let encodedPath = try JSONEncoder().encode(codablePath)
+                let decodedPath = try JSONDecoder().decode([String].self, from: encodedPath)
+                reportNavigation(prefix: prefix, path: decodedPath, reason: reason)
+            } catch {
+                reportNavigation(prefix: prefix, path: unencodablePath, reason: reason)
+            }
         } else {
             reportNavigation(prefix: prefix, path: unencodablePath, reason: reason)
         }


### PR DESCRIPTION
## Which problem is this PR solving?
- Navigation instrumentation was still reporting paths as `[]` when clients were using a `NavigationPath` to store their path (instead of an array)

## Short description of the changes
Change how we encode `NavigationPath` objects for our instrumentation.

## How to verify that this has the expected result
- [x] smoke tests pass

---

- [x] CHANGELOG is updated
- [x] ~~README is updated with documentation~~ N/A
