### PR TITLE
feat: Allow optional API key for custom endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+### New Features
+
+* Allow optional API key for custom endpoint
+
 ## 0.0.7
 
 ### New Features

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -67,13 +67,29 @@ private func matchesRegex(pattern: String, string: String) -> Bool {
 }
 
 /// Returns whether the passed in API key is classic or not.
-private func isClassic(key: String) -> Bool {
+private func isClassic(key: String?) -> Bool {
+    guard let key = key else {
+        return false
+    }
+    
     return switch key.count {
     case 0: false
     case 32: matchesRegex(pattern: classicKeyRegex, string: key)
     case 64: matchesRegex(pattern: ingestClassicKeyRegex, string: key)
     default: false
     }
+}
+
+private func isHoneycombEndpoint(endpoint: String) -> Bool {
+    guard let url = URL(string: endpoint) else {
+        return false
+    }
+    
+    guard let host = url.host else {
+        return false
+    }
+    
+    return host.hasSuffix(".honeycomb.io")
 }
 
 /// Gets the endpoint to use for a particular signal.
@@ -114,15 +130,18 @@ private func takeSecond(_: String, second: String) -> String {
 
 /// Gets the headers to use for a particular exporter.
 private func getHeaders(
-    apiKey: String,
+    apiKey: String?,
     dataset: String?,
     generalHeaders: [String: String],
     signalHeaders: [String: String]
 ) -> [String: String] {
     var headers = ["x-otlp-version": otlpVersion]
     headers.merge(generalHeaders, uniquingKeysWith: takeSecond)
+    
+    if let apiKey = apiKey {
+        headers.merge(["x-honeycomb-team": apiKey], uniquingKeysWith: takeSecond)
+    }
 
-    headers.merge(["x-honeycomb-team": apiKey], uniquingKeysWith: takeSecond)
     if let dataset = dataset {
         headers.merge(["x-honeycomb-dataset": dataset], uniquingKeysWith: takeSecond)
     }
@@ -158,9 +177,9 @@ extension Dictionary {
 /// https://opentelemetry.io/docs/languages/sdk-configuration/general/
 /// https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/
 public struct HoneycombOptions {
-    let tracesApiKey: String
-    let metricsApiKey: String
-    let logsApiKey: String
+    let tracesApiKey: String?
+    let metricsApiKey: String?
+    let logsApiKey: String?
     let dataset: String?
     let metricsDataset: String?
     let tracesEndpoint: String
@@ -484,14 +503,6 @@ public struct HoneycombOptions {
         }
 
         public func build() throws -> HoneycombOptions {
-            // If any API key isn't set, consider it a fatal error.
-            let defaultApiKey: () throws -> String = {
-                if self.apiKey == nil {
-                    throw HoneycombOptionsError.missingAPIKey("missing API key: call setAPIKey()")
-                }
-                return self.apiKey!
-            }
-
             // Collect the non-exporter-specific values.
             var resourceAttributes = self.resourceAttributes
             // Any explicit service name overrides the one in the resource attributes.
@@ -525,11 +536,42 @@ public struct HoneycombOptions {
                 "honeycomb.distro.runtime_version",
                 runtimeVersion
             )
+            
+            let tracesEndpoint = getHoneycombEndpoint(
+                endpoint: self.tracesEndpoint,
+                fallback: apiEndpoint,
+                proto: tracesProtocol ?? `protocol`,
+                suffix: "v1/traces"
+            )
+            let metricsEndpoint = getHoneycombEndpoint(
+                endpoint: self.metricsEndpoint,
+                fallback: apiEndpoint,
+                proto: metricsProtocol ?? `protocol`,
+                suffix: "v1/metrics"
+            )
+            let logsEndpoint = getHoneycombEndpoint(
+                endpoint: self.logsEndpoint,
+                fallback: apiEndpoint,
+                proto: logsProtocol ?? `protocol`,
+                suffix: "v1/logs"
+            )
 
-            let tracesApiKey: String = try self.tracesApiKey ?? defaultApiKey()
-            let metricsApiKey: String = try self.metricsApiKey ?? defaultApiKey()
-            let logsApiKey: String = try self.logsApiKey ?? defaultApiKey()
-
+            let tracesApiKey = self.tracesApiKey ?? self.apiKey
+            let metricsApiKey = self.metricsApiKey ?? self.apiKey
+            let logsApiKey = self.logsApiKey ?? self.apiKey
+            
+            if isHoneycombEndpoint(endpoint: tracesEndpoint) && tracesApiKey == nil {
+                throw HoneycombOptionsError.missingAPIKey("missing API key: call setAPIKey() or setTracesAPIKey()")
+            }
+            
+            if isHoneycombEndpoint(endpoint: metricsEndpoint) && metricsApiKey == nil {
+                throw HoneycombOptionsError.missingAPIKey("missing API key: call setAPIKey() or setMetricsAPIKey()")
+            }
+            
+            if isHoneycombEndpoint(endpoint: logsEndpoint) && logsApiKey == nil {
+                throw HoneycombOptionsError.missingAPIKey("missing API key: call setAPIKey() or setLogsAPIKey()")
+            }
+            
             let tracesHeaders =
                 getHeaders(
                     apiKey: tracesApiKey,
@@ -551,25 +593,6 @@ public struct HoneycombOptions {
                     generalHeaders: headers,
                     signalHeaders: self.logsHeaders
                 )
-
-            let tracesEndpoint = getHoneycombEndpoint(
-                endpoint: self.tracesEndpoint,
-                fallback: apiEndpoint,
-                proto: tracesProtocol ?? `protocol`,
-                suffix: "v1/traces"
-            )
-            let metricsEndpoint = getHoneycombEndpoint(
-                endpoint: self.metricsEndpoint,
-                fallback: apiEndpoint,
-                proto: metricsProtocol ?? `protocol`,
-                suffix: "v1/metrics"
-            )
-            let logsEndpoint = getHoneycombEndpoint(
-                endpoint: self.logsEndpoint,
-                fallback: apiEndpoint,
-                proto: logsProtocol ?? `protocol`,
-                suffix: "v1/logs"
-            )
 
             return HoneycombOptions(
                 tracesApiKey: tracesApiKey,

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -71,7 +71,7 @@ private func isClassic(key: String?) -> Bool {
     guard let key = key else {
         return false
     }
-    
+
     return switch key.count {
     case 0: false
     case 32: matchesRegex(pattern: classicKeyRegex, string: key)
@@ -84,11 +84,11 @@ private func isHoneycombEndpoint(endpoint: String) -> Bool {
     guard let url = URL(string: endpoint) else {
         return false
     }
-    
+
     guard let host = url.host else {
         return false
     }
-    
+
     return host.hasSuffix(".honeycomb.io")
 }
 
@@ -137,7 +137,7 @@ private func getHeaders(
 ) -> [String: String] {
     var headers = ["x-otlp-version": otlpVersion]
     headers.merge(generalHeaders, uniquingKeysWith: takeSecond)
-    
+
     if let apiKey = apiKey {
         headers.merge(["x-honeycomb-team": apiKey], uniquingKeysWith: takeSecond)
     }
@@ -536,7 +536,7 @@ public struct HoneycombOptions {
                 "honeycomb.distro.runtime_version",
                 runtimeVersion
             )
-            
+
             let tracesEndpoint = getHoneycombEndpoint(
                 endpoint: self.tracesEndpoint,
                 fallback: apiEndpoint,
@@ -559,19 +559,25 @@ public struct HoneycombOptions {
             let tracesApiKey = self.tracesApiKey ?? self.apiKey
             let metricsApiKey = self.metricsApiKey ?? self.apiKey
             let logsApiKey = self.logsApiKey ?? self.apiKey
-            
+
             if isHoneycombEndpoint(endpoint: tracesEndpoint) && tracesApiKey == nil {
-                throw HoneycombOptionsError.missingAPIKey("missing API key: call setAPIKey() or setTracesAPIKey()")
+                throw HoneycombOptionsError.missingAPIKey(
+                    "missing API key: call setAPIKey() or setTracesAPIKey()"
+                )
             }
-            
+
             if isHoneycombEndpoint(endpoint: metricsEndpoint) && metricsApiKey == nil {
-                throw HoneycombOptionsError.missingAPIKey("missing API key: call setAPIKey() or setMetricsAPIKey()")
+                throw HoneycombOptionsError.missingAPIKey(
+                    "missing API key: call setAPIKey() or setMetricsAPIKey()"
+                )
             }
-            
+
             if isHoneycombEndpoint(endpoint: logsEndpoint) && logsApiKey == nil {
-                throw HoneycombOptionsError.missingAPIKey("missing API key: call setAPIKey() or setLogsAPIKey()")
+                throw HoneycombOptionsError.missingAPIKey(
+                    "missing API key: call setAPIKey() or setLogsAPIKey()"
+                )
             }
-            
+
             let tracesHeaders =
                 getHeaders(
                     apiKey: tracesApiKey,

--- a/Tests/Honeycomb/HoneycombOptionsTests.swift
+++ b/Tests/Honeycomb/HoneycombOptionsTests.swift
@@ -741,16 +741,23 @@ final class HoneycombOptionsTests: XCTestCase {
     }
 
     func testMissingAPIKey() throws {
-        let data: [String: String] = [:]
-        let source = HoneycombOptionsSource(info: data)
+        var data: [String: String] = [:]
+        var source = HoneycombOptionsSource(info: data)
 
         XCTAssertThrowsError(try HoneycombOptions.Builder(source: source).build()) { e in
             XCTAssert(e is HoneycombOptionsError)
             XCTAssertEqual(
                 e as? HoneycombOptionsError,
-                .missingAPIKey("missing API key: call setAPIKey()")
+                .missingAPIKey("missing API key: call setAPIKey() or setTracesAPIKey()")
             )
         }
+        
+        data = [
+            "HONEYCOMB_API_ENDPOINT" : "https://custom.collector:443",
+        ]
+        source = HoneycombOptionsSource(info: data)
+        
+        XCTAssertNoThrow(try HoneycombOptions.Builder(source: source).build())
     }
 
     func testIncorrectType() throws {

--- a/Tests/Honeycomb/HoneycombOptionsTests.swift
+++ b/Tests/Honeycomb/HoneycombOptionsTests.swift
@@ -751,12 +751,12 @@ final class HoneycombOptionsTests: XCTestCase {
                 .missingAPIKey("missing API key: call setAPIKey() or setTracesAPIKey()")
             )
         }
-        
+
         data = [
-            "HONEYCOMB_API_ENDPOINT" : "https://custom.collector:443",
+            "HONEYCOMB_API_ENDPOINT": "https://custom.collector:443"
         ]
         source = HoneycombOptionsSource(info: data)
-        
+
         XCTAssertNoThrow(try HoneycombOptions.Builder(source: source).build())
     }
 


### PR DESCRIPTION
## Short description of the changes

If you are not sending directly to honeycomb and using some kind of pipeline involving refinery or collectors then you shouldn't need to provide the API key. 

This adds similar logic from the web SDK. https://github.com/honeycombio/honeycomb-opentelemetry-web/pull/477

It feels a little messy so please suggest a totally different way to do this if you can think of one 🙏 

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
