### PR TITLE
maint: make Package.swift work with dependabot again

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,13 +25,11 @@ let package = Package(
             name: "Honeycomb",
             dependencies: [
                 .product(name: "BaggagePropagationProcessor", package: "opentelemetry-swift"),
-                .product(name: "NetworkStatus", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetryApi", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetryProtocolExporter", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetryProtocolExporterHTTP", package: "opentelemetry-swift"),
                 .product(name: "PersistenceExporter", package: "opentelemetry-swift"),
-                .product(name: "ResourceExtension", package: "opentelemetry-swift"),
                 .product(name: "StdoutExporter", package: "opentelemetry-swift"),
             ]
         ),
@@ -45,3 +43,16 @@ let package = Package(
         ),
     ]
 )
+.addPlatformSpecific()
+
+extension Package {
+    func addPlatformSpecific() -> Self {
+        #if canImport(Darwin)
+            targets[0].dependencies
+                .append(.product(name: "NetworkStatus", package: "opentelemetry-swift"))
+            targets[0].dependencies
+                .append(.product(name: "ResourceExtension", package: "opentelemetry-swift"))
+        #endif
+        return self
+    }
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Dependabot runs on ubuntu, but several of our upstream dependencies are only defined on Darwin, so it was failing to resolve the packages.

## Short description of the changes

This PR uses the same technique as the [upstream repo](https://github.com/open-telemetry/opentelemetry-swift/blob/342452f72ae7ce20136747d91033ad88b4430930/Package.swift#L142) to exclude the dependencies that aren't defined. Those dependencies aren't even versioned, so this shouldn't cause any lack of coverage.

This shouldn't affect any customers, because we don't support non-Darwin platforms anyway.

## How to verify that this has the expected result

* smoke-tests still pass
* i don't know any way to test whether this fixes dependabot without checking it in :-/

---

~- [ ] CHANGELOG is updated~ N/A
~- [ ] README is updated with documentation~ N/A
