### PR TITLE
feat: include stack trace info in MXCrashDiagnostic and MXHangDiagnostic payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+### New Features
+
+* `metrickit.diagnostic.crash` and `metrickit.diagnostic.hang` traces now include `stacktrace_json` attributes containing the raw (unsymbolicated) stacktrace supplied by the OS.
+
 ## 0.0.10
 
 ### New Features

--- a/Examples/SmokeTest/SmokeTest/MetricKitTestHelpers.swift
+++ b/Examples/SmokeTest/SmokeTest/MetricKitTestHelpers.swift
@@ -437,6 +437,9 @@ class FakeMetricPayload: MXMetricPayload {
 
 @available(iOS 14.0, *)
 class FakeCallStackTree: MXCallStackTree {
+    override func jsonRepresentation() -> Data {
+        return Data("fake json stacktrace".utf8)
+    }
 }
 
 @available(iOS 14.0, *)

--- a/Sources/Honeycomb/MetricKitSubscriber.swift
+++ b/Sources/Honeycomb/MetricKitSubscriber.swift
@@ -396,9 +396,16 @@
             ]
         }
         logForEach(payload.hangDiagnostics, "hang") {
-            [
-                "hang_duration": $0.hangDuration
-            ]
+            var attrs: [String: AttributeValueConvertable] = [:]
+            attrs["hang_duration"] = $0.hangDuration
+
+            let callStackTree = $0.callStackTree
+            attrs["exception.stacktrace_json"] = String(
+                decoding: callStackTree.jsonRepresentation(),
+                as: UTF8.self
+            )
+
+            return attrs
         }
         logForEach(payload.cpuExceptionDiagnostics, "cpu_exception") {
             [
@@ -420,6 +427,12 @@
             if let terminationReason = $0.terminationReason {
                 attrs["exception.termination_reason"] = terminationReason
             }
+            let callStackTree = $0.callStackTree
+            attrs["exception.stacktrace_json"] = String(
+                decoding: callStackTree.jsonRepresentation(),
+                as: UTF8.self
+            )
+
             if #available(iOS 17.0, *) {
                 if let exceptionReason = $0.exceptionReason {
                     attrs["exception.objc.type"] = exceptionReason.exceptionType

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -182,6 +182,7 @@ mk_diag_attr() {
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.cpu_exception.total_sampled_time" double)" 194400  # 54 hours
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.disk_write_exception.total_writes_caused" double)" 55000000  # 55 MB
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.hang.hang_duration" double)" 56
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.hang.exception.stacktrace_json" string)" '"fake json stacktrace"'
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.mach_execution_type" int)" '"57"'
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.code" int)" '"58"'
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.signal" int)" '"59"'
@@ -190,6 +191,7 @@ mk_diag_attr() {
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.termination_reason" string)" '"reason"'
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.objc.name" string)" '"MyCrash"'
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.objc.classname" string)" '"MyClass"'
+  assert_equal "$(mk_diag_attr "metrickit.diagnostic.crash.exception.stacktrace_json" string)" '"fake json stacktrace"'
   assert_equal "$(mk_diag_attr "metrickit.diagnostic.app_launch.launch_duration" double)" 60
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
Includes stack trace info in MXCrashDiagnostic and MXHangDiagnostic payloads

## Short description of the changes
Both `MXCrashDiagnostic` and `MXHangDiagnostic` objects include a `callStackTree` property of type `MXCallStackTree`. That class has only one useful function: [`jsonRepresenation()`](https://developer.apple.com/documentation/metrickit/mxcallstacktree/jsonrepresentation()). 

So we'll pass that through on the trace and symbolicate it properly in the collector plugin. 

## How to verify that this has the expected result
- [x] smoke tests pass

---

- [x] CHANGELOG is updated
- [ ] ~README is updated with documentation~ N/A
