### PR TITLE
fix: refine attributes for manual error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+### New Features
+
+* Add optional `severity` parameter to manual error-logging APIs.
+
+### Fixes
+
+* Change logging of `NSError` and Swift `Error` to match semantic conventions for _errors_, not _exceptions_.
+
 ## 0.0.11
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Both helpers also accept 2 optional parameters: `prefix: String` and `reason: St
 
 ### Manual Error Logging
 
-Any Errors, NSErrors, or NSExceptions may be recorded as Log records using the `log` method. This can be used for logging 
+Any `Error`s, `NSError`s, or `NSException`s may be recorded as Log records using the `log` method. This can be used for logging 
 any caught exceptions in your own code that will not be logged by our crash instrumentation.
 
 Below is an example of logging an Error object using several custom attributes.
@@ -413,12 +413,29 @@ catch let error {
 ```
 
 | Argument        | Type                               | Is Required | Description                                                                                                          |
-|-----------------|------------------------------------|-------------|---------------------------------------------------------------------------------------------------------             |
+|-----------------|------------------------------------|-------------|----------------------------------------------------------------------------------------------------------------------|
 | error/exception | Error/NSError/NSException          | true        | The error or exception itself. Depending on the type of error, fields will be automatically added to the log record. |
 | attributes      | Dictionary<string, AttributeValue> | false       | Additional attributes you would like to log along with the default ones provided.                                    |
 | thread          | Thread                             | false       | Thread where the error occurred. Add this to include additional attributes related to the thread                     |
+| severity        | Severity                           | false       | The OpenTelemetry severity to attach to the log entry. Defaults to `.error` for manual errors.                       |
 | logger          | Logger                             | false       | Defaults to the Honeycomb error `Logger`. Provide if you want to use a different OpenTelemetry `Logger`              |
 
+The following attributes are automatically attached to the log entry.
+
+#### Swift `Error`
+* `error.type` - The type name of the `Error` subclass.
+* `error.message` - The `localizedDescription` of the `Error`.
+
+#### `NSError`
+* `error.type` - The type name of the `NSError` subclass.
+* `error.message` - The `localizedDescription` of the `NSError`.
+* `nserror.code` - The `code` of the `NSError`.
+* `nserror.domain` - The `domain` of the `NSError`.
+
+#### `NSException`
+* `exception.type` - The `name` of the `NSException`.
+* `exception.message` - The `reason` of the `NSException`.
+* `exception.stacktrace` - The stack trace of the exception.
 
  ## Offline Caching
 

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -306,9 +306,10 @@ public class Honeycomb {
 
         // TODO: Type and name seem wrong here. Which is right?
         var errorAttributes = [
-            "exception.type": type.attributeValue(),
-            "exception.message": message.attributeValue(),
-            "exception.stacktrace": exception.callStackSymbols.joined(separator: "\n")
+            SemanticAttributes.exceptionType.rawValue: type.attributeValue(),
+            SemanticAttributes.exceptionMessage.rawValue: message.attributeValue(),
+            SemanticAttributes.exceptionStacktrace.rawValue: exception.callStackSymbols
+                .joined(separator: "\n")
                 .attributeValue(),
         ]
         .merging(attributes, uniquingKeysWith: { (_, last) in last })

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -262,6 +262,7 @@ public class Honeycomb {
         error: NSError,
         attributes: [String: AttributeValue] = [:],
         thread: Thread?,
+        severity: Severity = .error,
         logger: OpenTelemetryApi.Logger = getDefaultErrorLogger()
     ) {
         let timestamp = Date()
@@ -282,7 +283,7 @@ public class Honeycomb {
             errorAttributes["thread.name"] = name.attributeValue()
         }
 
-        logError(errorAttributes, .error, logger, timestamp)
+        logError(errorAttributes, severity, logger, timestamp)
     }
 
     /// Logs an `NSException`. This can be used for logging any caught exceptions in your own code that will not be logged by our crash instrumentation.
@@ -329,6 +330,7 @@ public class Honeycomb {
         error: Error,
         attributes: [String: AttributeValue] = [:],
         thread: Thread?,
+        severity: Severity = .error,
         logger: OpenTelemetryApi.Logger = getDefaultErrorLogger()
     ) {
         let timestamp = Date()
@@ -345,7 +347,7 @@ public class Honeycomb {
             errorAttributes["thread.name"] = name.attributeValue()
         }
 
-        logError(errorAttributes, .error, logger, timestamp)
+        logError(errorAttributes, severity, logger, timestamp)
     }
 
     private static func logError(

--- a/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
+++ b/Sources/Honeycomb/HoneycombUncaughtExceptions.swift
@@ -8,7 +8,7 @@ internal class HoneycombUncaughtExceptionHandler {
             NSGetUncaughtExceptionHandler()
 
         NSSetUncaughtExceptionHandler { exception in
-            Honeycomb.log(exception: exception, thread: Thread.current)
+            Honeycomb.log(exception: exception, thread: Thread.current, severity: .fatal)
 
             // App is about to close taking Otel with it, give it some time to finish
             Thread.sleep(forTimeInterval: 3.0)

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -427,31 +427,40 @@ mk_diag_attr() {
 }
 
 @test "NSException attributes are correct" {
-    stacktrace=$(attribute_for_exception_log_of_type "NSException" "exception.stacktrace" string)
-    type=$(attribute_for_exception_log_of_type "NSException" "exception.type" string)
-    message=$(attribute_for_exception_log_of_type "NSException" "exception.message" string)
-    name=$(attribute_for_exception_log_of_type "NSException" "exception.name" string)
+    stacktrace=$(attribute_for_exception_log_of_type "TestException" "exception.stacktrace" string)
+    type=$(attribute_for_exception_log_of_type "TestException" "exception.type" string)
+    message=$(attribute_for_exception_log_of_type "TestException" "exception.message" string)
+    severity=$(logs_from_scope_named "io.honeycomb.error" \
+        | jq "select(.attributes[].value.stringValue == \"TestException\") | .severityText")
 
     assert_not_empty "$stacktrace"
-    assert_equal "$type" '"NSException"'
     assert_equal "$message" '"Exception Handling reason"'
-    assert_equal "$name" '"TestException"'
+    assert_equal "$type" '"TestException"'
+    assert_equal "$severity" '"FATAL"'
 }
 
 @test "NSError attributes are correct" {
-    code=$(attribute_for_exception_log_of_type "NSError" "exception.code" int)
-    type=$(attribute_for_exception_log_of_type "NSError" "exception.type" string)
-    message=$(attribute_for_exception_log_of_type "NSError" "exception.message" string)
+    code=$(attribute_for_exception_log_of_type "NSError" "nserror.code" int)
+    domain=$(attribute_for_exception_log_of_type "NSError" "nserror.domain" string)
+    type=$(attribute_for_exception_log_of_type "NSError" "error.type" string)
+    message=$(attribute_for_exception_log_of_type "NSError" "error.message" string)
+    severity=$(logs_from_scope_named "io.honeycomb.error" \
+        | jq "select(.attributes[].value.stringValue == \"NSError\") | .severityText")
 
     assert_equal "$code" '"-1"'
+    assert_equal "$domain" '"Test Error"'
     assert_equal "$type" '"NSError"'
     assert_equal "$message" "\"The operation couldn’t be completed. (Test Error error -1.)\""
+    assert_equal "$severity" '"ERROR"'
 }
 
 @test "Swift Error attributes are correct" {
-    type=$(attribute_for_exception_log_of_type "TestError" "exception.type" string)
-    message=$(attribute_for_exception_log_of_type "TestError" "exception.message" string)
+    type=$(attribute_for_exception_log_of_type "TestError" "error.type" string)
+    message=$(attribute_for_exception_log_of_type "TestError" "error.message" string)
+    severity=$(logs_from_scope_named "io.honeycomb.error" \
+        | jq "select(.attributes[].value.stringValue == \"TestError\") | .severityText")
 
     assert_equal "$type" '"TestError"'
     assert_equal "$message" "\"The operation couldn’t be completed. (SmokeTest.TestError error 0.)\""
+    assert_equal "$severity" '"ERROR"'
 }


### PR DESCRIPTION
## Which problem is this PR solving?

This refines the attributes for manual error logging to better match semantic conventions, and also makes it possible for us to differentiate fatal _crashes_ from non-fatal _errors_.

## Short description of the changes

* Add optional `severity` parameter to manual error-logging APIs.
* Change logging of `NSError` and Swift `Error` to match semantic conventions for _errors_, not _exceptions_.

## How to verify that this has the expected result

Smoke tests are updated.

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
