### PR TITLE
feat: add build info to resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Honeycomb OpenTelemetry SDK Changelog
 ### New Features
 
 * Add optional `severity` parameter to manual error-logging APIs.
+* Add new resource attributes with build and version information.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ To manually send a span:
 ## Default Attributes
 All spans will include the following attributes
 
+- `app.bundle.version`: The version number of the app, as given by [`CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleversion)
+- `app.bundle.shortVersionString`: The short version string of the app, as given by [`CFBundleShortVersionVersion`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleshortversionstring)
+- `app.debug.buildUUID`: Debug UUID of app.
+- `app.debug.binaryName`: The name of the app binary with the UUID given in `app.debug.buildUUID`
+- `app.bundle.executable`: The name of the app executable, as given by [`CFBundleExecutable`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleexecutable) 
 - `honeycomb.distro.runtime_version`: Version of iOS on the device. See also `os.description`.
 - `honeycomb.distro.version`: Version of the Honeycomb SDK being used.
 - `os.description`: String containing iOS version, build ID, and SDK level.

--- a/Sources/Honeycomb/AppInfoResources.swift
+++ b/Sources/Honeycomb/AppInfoResources.swift
@@ -3,21 +3,27 @@ import MachO
 import OpenTelemetryApi
 import OpenTelemetrySdk
 
+// none of these are in the semconv yet so we can call them whatever we like
+let APP_BUNDLE_VERSION = "app.bundle.version"
+let APP_BUNDLE_SHORT_VERSION_STRING = "app.bundle.shortVersionString"
+let APP_DEBUG_BUILD_UUID = "app.debug.buildUUID"
+let APP_DEBUG_BINARY_NAME = "app.debug.binaryName"
+let APP_BUNDLE_EXECUTABLE = "app.bundle.executable"
+
 public func getAppResources() -> [String: String] {
-    print(Bundle.main.infoDictionary)
     var result: [String: String] = [:]
     if let version = getVersion() {
-        result["app.bundle.version"] = version
+        result[APP_BUNDLE_VERSION] = version
     }
     if let shortVersionString = getShortVersionString() {
-        result["app.bundle.shortVersionString"] = shortVersionString
+        result[APP_BUNDLE_SHORT_VERSION_STRING] = shortVersionString
     }
     if let buildUUID = getBuildUUID() {
-        result["app.debug.buildUUID"] = buildUUID
-        result["app.debug.binaryName"] = getBinaryName()
+        result[APP_DEBUG_BUILD_UUID] = buildUUID
+        result[APP_DEBUG_BINARY_NAME] = getBinaryName()
     }
     if let executable = getExecutable() {
-        result["app.bundle.executable"] = executable
+        result[APP_BUNDLE_EXECUTABLE] = executable
     }
     return result
 }

--- a/Sources/Honeycomb/AppInfoResources.swift
+++ b/Sources/Honeycomb/AppInfoResources.swift
@@ -46,13 +46,25 @@ private func getBuildUUID() -> String? {
                 let bytes = rawPtr.bindMemory(to: UInt8.self)
 
                 // Format: 8-4-4-4-12
-                return String(format:
-                    "%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
-                    bytes[0], bytes[1], bytes[2], bytes[3],
-                    bytes[4], bytes[5],
-                    bytes[6], bytes[7],
-                    bytes[8], bytes[9],
-                    bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+                return String(
+                    format:
+                        "%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+                    bytes[0],
+                    bytes[1],
+                    bytes[2],
+                    bytes[3],
+                    bytes[4],
+                    bytes[5],
+                    bytes[6],
+                    bytes[7],
+                    bytes[8],
+                    bytes[9],
+                    bytes[10],
+                    bytes[11],
+                    bytes[12],
+                    bytes[13],
+                    bytes[14],
+                    bytes[15]
                 )
             }
 

--- a/Sources/Honeycomb/AppInfoResources.swift
+++ b/Sources/Honeycomb/AppInfoResources.swift
@@ -4,26 +4,26 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 
 // none of these are in the semconv yet so we can call them whatever we like
-let APP_BUNDLE_VERSION = "app.bundle.version"
-let APP_BUNDLE_SHORT_VERSION_STRING = "app.bundle.shortVersionString"
-let APP_DEBUG_BUILD_UUID = "app.debug.buildUUID"
-let APP_DEBUG_BINARY_NAME = "app.debug.binaryName"
-let APP_BUNDLE_EXECUTABLE = "app.bundle.executable"
+let appBundleVersion = "app.bundle.version"
+let appBundleShortVersionString = "app.bundle.shortVersionString"
+let appDebugBuildUUID = "app.debug.buildUUID"
+let appDebugBinaryName = "app.debug.binaryName"
+let appBundleExecutable = "app.bundle.executable"
 
 public func getAppResources() -> [String: String] {
     var result: [String: String] = [:]
     if let version = getVersion() {
-        result[APP_BUNDLE_VERSION] = version
+        result[appBundleVersion] = version
     }
     if let shortVersionString = getShortVersionString() {
-        result[APP_BUNDLE_SHORT_VERSION_STRING] = shortVersionString
+        result[appBundleShortVersionString] = shortVersionString
     }
     if let buildUUID = getBuildUUID() {
-        result[APP_DEBUG_BUILD_UUID] = buildUUID
-        result[APP_DEBUG_BINARY_NAME] = getBinaryName()
+        result[appDebugBuildUUID] = buildUUID
+        result[appDebugBinaryName] = getBinaryName()
     }
     if let executable = getExecutable() {
-        result[APP_BUNDLE_EXECUTABLE] = executable
+        result[appBundleExecutable] = executable
     }
     return result
 }

--- a/Sources/Honeycomb/AppInfoResources.swift
+++ b/Sources/Honeycomb/AppInfoResources.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MachO
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+public func getAppResources() -> [String: String] {
+    print(Bundle.main.infoDictionary)
+    var result: [String: String] = [:]
+    if let version = getVersion() {
+        result["app.bundle.version"] = version
+    }
+    if let shortVersionString = getShortVersionString() {
+        result["app.bundle.shortVersionString"] = shortVersionString
+    }
+    if let buildUUID = getBuildUUID() {
+        result["app.debug.buildUUID"] = buildUUID
+        result["app.debug.binaryName"] = getBinaryName()
+    }
+    if let executable = getExecutable() {
+        result["app.bundle.executable"] = executable
+    }
+    return result
+}
+
+private func getBinaryName() -> String {
+    return String(cString: _dyld_get_image_name(0))
+}
+
+private func getBuildUUID() -> String? {
+    guard let header = _dyld_get_image_header(0) else {
+        return nil
+    }
+
+    var cursor = UnsafeRawPointer(header)
+        .advanced(by: MemoryLayout<mach_header_64>.size)
+        .assumingMemoryBound(to: load_command.self)
+
+    for _ in 0..<header.pointee.ncmds {
+        if cursor.pointee.cmd == LC_UUID {
+            let uuidCmd = UnsafeRawPointer(cursor)
+                .assumingMemoryBound(to: uuid_command.self)
+
+            let uuidTuple = uuidCmd.pointee.uuid
+
+            let uuidStr = withUnsafeBytes(of: uuidTuple) { rawPtr -> String in
+                let bytes = rawPtr.bindMemory(to: UInt8.self)
+
+                // Format: 8-4-4-4-12
+                return String(format:
+                    "%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+                    bytes[0], bytes[1], bytes[2], bytes[3],
+                    bytes[4], bytes[5],
+                    bytes[6], bytes[7],
+                    bytes[8], bytes[9],
+                    bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+                )
+            }
+
+            return uuidStr
+        }
+        cursor = UnsafeRawPointer(cursor)
+            .advanced(by: Int(cursor.pointee.cmdsize))
+            .assumingMemoryBound(to: load_command.self)
+    }
+
+    return nil
+}
+
+private func getShortVersionString() -> String? {
+    return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+}
+
+private func getVersion() -> String? {
+    return Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+}
+
+private func getExecutable() -> String? {
+    return Bundle.main.infoDictionary?["CFBundleExecutable"] as? String
+}

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -69,6 +69,7 @@ public class Honeycomb {
 
         let resource = DefaultResources().get()
             .merging(other: Resource(attributes: createAttributeDict(options.resourceAttributes)))
+            .merging(other: Resource(attributes: createAttributeDict(getAppResources())))
 
         // Traces
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -37,6 +37,28 @@ teardown_file() {
   assert_equal "$(resource_attributes_received | jq 'select (.key == "os.description").value.stringValue' | uniq)" '"iOS Version 17.5 (Build 21F79)"'
   assert_equal "$(resource_attributes_received | jq 'select (.key == "os.name").value.stringValue' | uniq)" '"iOS"'
   assert_equal "$(resource_attributes_received | jq 'select (.key == "os.version").value.stringValue' | uniq)" '"17.5.0"'
+  
+  all_resource_attributes=$(resource_attributes_received | jq ".key"  | sort | uniq)
+  assert_equal "$all_resource_attributes" '"app.bundle.executable"
+"app.bundle.shortVersionString"
+"app.bundle.version"
+"app.debug.binaryName"
+"app.debug.buildUUID"
+"device.id"
+"device.model.identifier"
+"honeycomb.distro.runtime_version"
+"honeycomb.distro.version"
+"os.description"
+"os.name"
+"os.type"
+"os.version"
+"service.name"
+"service.version"
+"telemetry.distro.name"
+"telemetry.distro.version"
+"telemetry.sdk.language"
+"telemetry.sdk.name"
+"telemetry.sdk.version"'
 }
 
 @test "Spans have network attributes" {

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -37,28 +37,6 @@ teardown_file() {
   assert_equal "$(resource_attributes_received | jq 'select (.key == "os.description").value.stringValue' | uniq)" '"iOS Version 17.5 (Build 21F79)"'
   assert_equal "$(resource_attributes_received | jq 'select (.key == "os.name").value.stringValue' | uniq)" '"iOS"'
   assert_equal "$(resource_attributes_received | jq 'select (.key == "os.version").value.stringValue' | uniq)" '"17.5.0"'
-  
-  all_resource_attributes=$(resource_attributes_received | jq ".key"  | sort | uniq)
-  assert_equal "$all_resource_attributes" '"app.bundle.executable"
-"app.bundle.shortVersionString"
-"app.bundle.version"
-"app.debug.binaryName"
-"app.debug.buildUUID"
-"device.id"
-"device.model.identifier"
-"honeycomb.distro.runtime_version"
-"honeycomb.distro.version"
-"os.description"
-"os.name"
-"os.type"
-"os.version"
-"service.name"
-"service.version"
-"telemetry.distro.name"
-"telemetry.distro.version"
-"telemetry.sdk.language"
-"telemetry.sdk.name"
-"telemetry.sdk.version"'
 }
 
 @test "Spans have network attributes" {
@@ -71,7 +49,12 @@ teardown_file() {
 
 @test "SDK sends correct resource attributes" {
   result=$(resource_attributes_received | jq ".key" | sort | uniq)
-  assert_equal "$result" '"device.id"
+  assert_equal "$result" '"app.bundle.executable"
+"app.bundle.shortVersionString"
+"app.bundle.version"
+"app.debug.binaryName"
+"app.debug.buildUUID"
+"device.id"
 "device.model.identifier"
 "honeycomb.distro.runtime_version"
 "honeycomb.distro.version"


### PR DESCRIPTION
## Which problem is this PR solving?
Adds resource attributes to enable us to symbolicate stacktraces from our exception logger

## Short description of the changes
The important ones are `app.debug.buildUUID` and `app.debug.binaryName`. In my tests, `app.debug.binaryName` spat out `/Library/Developer/CoreSimulator/Volumes/iOS_22C150/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.2.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libLogRedirect.dylib`, not the actual executable name like I expected. This might be because I was running the app in the xcode simulator; we'll have to experiment with an actual compiled app on a device. 

Anyways I added `app.bundle.executable` to make up for that, which looks like it contains the actual binary name in it.  

While I was in here, I added code to pull the version number info out of the bundle as well, since that was fairly straightforward. 

## How to verify that this has the expected result
- [x] Tests pass

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
