### PR TITLE
fix: update `app.debug.buildUUID` attribute to `app.debug.build_uuid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ All spans will include the following attributes
 
 - `app.bundle.version`: The version number of the app, as given by [`CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleversion)
 - `app.bundle.shortVersionString`: The short version string of the app, as given by [`CFBundleShortVersionVersion`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleshortversionstring)
-- `app.debug.buildUUID`: Debug UUID of app.
-- `app.debug.binaryName`: The name of the app binary with the UUID given in `app.debug.buildUUID`
+- `app.debug.build_uuid`: Debug UUID of app.
+- `app.debug.binaryName`: The name of the app binary with the UUID given in `app.debug.build_uuid`
 - `app.bundle.executable`: The name of the app executable, as given by [`CFBundleExecutable`](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleexecutable) 
 - `honeycomb.distro.runtime_version`: Version of iOS on the device. See also `os.description`.
 - `honeycomb.distro.version`: Version of the Honeycomb SDK being used.

--- a/Sources/Honeycomb/AppInfoResources.swift
+++ b/Sources/Honeycomb/AppInfoResources.swift
@@ -6,7 +6,7 @@ import OpenTelemetrySdk
 // none of these are in the semconv yet so we can call them whatever we like
 let appBundleVersion = "app.bundle.version"
 let appBundleShortVersionString = "app.bundle.shortVersionString"
-let appDebugBuildUUID = "app.debug.buildUUID"
+let appDebugBuildUUID = "app.debug.build_uuid"
 let appDebugBinaryName = "app.debug.binaryName"
 let appBundleExecutable = "app.bundle.executable"
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -53,7 +53,7 @@ teardown_file() {
 "app.bundle.shortVersionString"
 "app.bundle.version"
 "app.debug.binaryName"
-"app.debug.buildUUID"
+"app.debug.build_uuid"
 "device.id"
 "device.model.identifier"
 "honeycomb.distro.runtime_version"


### PR DESCRIPTION
Follow up of #85 

## Which problem is this PR solving?
In https://github.com/honeycombio/opentelemetry-collector-symbolicator/pull/73, we decided this should be spelled `app.debug.build_uuid` instead of `app.debug.buildUUID`. 

## Short description of the changes
What it says on the tin

## How to verify that this has the expected result
- [x] tests pass

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
