### PR TITLE
maint: add tests for specific otel version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ workflows:
               otel_version:
                 - 1.15.0
                 - 1.16.1
+                - 1.17.1
       - cocoapods_lint
       - cocoapods_test
 
@@ -173,6 +174,7 @@ workflows:
               otel_version:
                 - 1.15.0
                 - 1.16.1
+                - 1.17.1
       - cocoapods_lint:
           <<: *filters_always
       - cocoapods_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,6 @@ workflows:
               otel_version:
                 - 1.15.0
                 - 1.16.1
-                - 2.0.0
       - cocoapods_lint
       - cocoapods_test
 
@@ -174,7 +173,6 @@ workflows:
               otel_version:
                 - 1.15.0
                 - 1.16.1
-                - 2.0.0
       - cocoapods_lint:
           <<: *filters_always
       - cocoapods_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,9 @@ jobs:
       - run: make cocoapods-test
 
   smoke_tests:
+    parameters:
+      otel_version:
+        type: string
     macos:
       xcode: 15.4.0
     resource_class: m4pro.medium
@@ -108,6 +111,9 @@ jobs:
           command: npm install && npm start
           background: true
       - run:
+          name: Set opentelemetry-swift version
+          command: ./set-otel-version.sh << parameters.otel_version >>
+      - run:
           name: Run iOS App
           command: make ios-tests
       - run:
@@ -136,7 +142,13 @@ workflows:
                 - generic/platform=tvOS
                 - generic/platform=watchOS
       - tests
-      - smoke_tests
+      - smoke_tests:
+          matrix:
+            parameters:
+              otel_version:
+                - 1.15.0
+                - 1.16.1
+                - 2.0.0
       - cocoapods_lint
       - cocoapods_test
 
@@ -157,6 +169,12 @@ workflows:
           <<: *filters_always
       - smoke_tests:
           <<: *filters_always
+          matrix:
+            parameters:
+              otel_version:
+                - 1.15.0
+                - 1.16.1
+                - 2.0.0
       - cocoapods_lint:
           <<: *filters_always
       - cocoapods_test:

--- a/set-otel-version.sh
+++ b/set-otel-version.sh
@@ -1,0 +1,8 @@
+# A script to set a specific version of opentelemetry-swift to depend on.
+# This is intended for automated testing, and not to be used manually.
+#
+# usage: ./set-otel-version.sh 1.2.3
+#
+set -e
+
+sed -i "" -e 's/opentelemetry-swift.git", [a-z]*: "[0-9.]*"/opentelemetry-swift.git", exact: "'$1'"/' Package.swift


### PR DESCRIPTION
## Which problem is this PR solving?

We have customers using several different version of opentelemetry-swift, and we want to be able to test with each of them.

## Short description of the changes

Minor changes to add continuous tests for specific opentelemetry-swift versions.

## How to verify that this has the expected result

The new CI tests should pass.

---

~- [ ] CHANGELOG is updated~ N/A
~- [ ] README is updated with documentation~ N/A
