### PR TITLE
maint: remove the sleep after flush

### DIFF
--- a/Examples/SmokeTest/SmokeTest/ContentView.swift
+++ b/Examples/SmokeTest/SmokeTest/ContentView.swift
@@ -31,7 +31,7 @@ private func flush() {
     // garbage-collected and the http request will never be sent. Until that behavior is
     // fixed, it's necessary to sleep here, to allow the outstanding HTTP requests to be
     // processed.
-    Thread.sleep(forTimeInterval: 3.0)
+    // Thread.sleep(forTimeInterval: 3.0)
 }
 
 private func sendFakeNSError() {


### PR DESCRIPTION
## Which problem is this PR solving?

Our tests have a sleep after flush. This used to be necessary. This PR is testing if it still is.
  
## Short description of the changes

This is just a change to remove the sleep.

## How to verify that this has the expected result

Running the smoke tests a few times.

---

~- [ ] CHANGELOG is updated~
~- [ ] README is updated with documentation~
