### PR TITLE
fix: make builder class open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* fix: builder class is not extendable outside of package 
+
 ## v 0.0.15
 
 ### New Features

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -216,7 +216,7 @@ public struct HoneycombOptions {
 
     let offlineCachingEnabled: Bool
 
-    @objc public class Builder: NSObject {
+    @objc open class Builder: NSObject {
         private var apiKey: String? = nil
         private var tracesApiKey: String? = nil
         private var metricsApiKey: String? = nil


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We need to be able to expose the builder class to React Native.

- Closes #<enter issue here>

## Short description of the changes

Make builder class `open` and enable us to extend it outside of swift.

## How to verify that this has the expected result

---

- [X] CHANGELOG is updated
- [X] README is updated with documentation
