### PR TITLE
fix: add objectivC typealias for honeycomb options builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* fix: add objectiveC alias for type
+
 ## v 0.0.16
 
 * fix: builder class is not extendable outside of package 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
-* fix: add objectiveC alias for type
+* fix: add Objective-C alias for type
 
 ## v 0.0.16
 

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -215,8 +215,7 @@ public struct HoneycombOptions {
     let unhandledExceptionInstrumentationEnabled: Bool
 
     let offlineCachingEnabled: Bool
-
-    @objc open class Builder: NSObject {
+    @objc(HNYOptions) open class Builder: NSObject {
         private var apiKey: String? = nil
         private var tracesApiKey: String? = nil
         private var metricsApiKey: String? = nil


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
`HoneycombOptions.Builder` shows up as just `Builder` in ObjectiveC.

- Closes #<enter issue here>

## Short description of the changes
Added a typealias so that `HoneycombOptions.Builder` will appear as `HNYOptions` instead of `Builder`


## How to verify that this has the expected result

---

- [X] CHANGELOG is updated
- [N/A] README is updated with documentation
