### PR TITLE
feat: expose OpenTelemetry Resource as public property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* feat: expose OpenTelemetry Resource as public property
+
 ## 2.0.0
 
 * maint: Update to OpenTelemetry 2.x.

--- a/Tests/Honeycomb/HoneycombOptionsTests.swift
+++ b/Tests/Honeycomb/HoneycombOptionsTests.swift
@@ -836,4 +836,33 @@ final class HoneycombOptionsTests: XCTestCase {
             )
         }
     }
+
+    func testResourceExposureAfterConfiguration() throws {
+        let customAttributes = [
+            "environment": "test",
+            "custom.attr2": "custom-value2",
+            "custom.attr": "custom-value"
+        ]
+        
+        let options = try HoneycombOptions.Builder()
+            .setAPIKey("test-key")
+            .setServiceName("test-service")
+            .setResourceAttributes(customAttributes)
+            .build()
+
+        try Honeycomb.configure(options: options)
+
+        // Resource is always available (non-null)
+        let resource = Honeycomb.resource
+        let attributes = resource.attributes
+        
+        // Test standard attributes
+        XCTAssertEqual(attributes["service.name"]?.description, "test-service")
+        XCTAssertEqual(attributes["telemetry.distro.name"]?.description, "honeycomb-opentelemetry-swift")
+        
+        // Test custom attributes
+        XCTAssertEqual(attributes["environment"]?.description, "test")
+        XCTAssertEqual(attributes["custom.attr2"]?.description, "custom-value2")
+        XCTAssertEqual(attributes["custom.attr"]?.description, "custom-value")
+    }
 }

--- a/Tests/Honeycomb/HoneycombOptionsTests.swift
+++ b/Tests/Honeycomb/HoneycombOptionsTests.swift
@@ -841,9 +841,9 @@ final class HoneycombOptionsTests: XCTestCase {
         let customAttributes = [
             "environment": "test",
             "custom.attr2": "custom-value2",
-            "custom.attr": "custom-value"
+            "custom.attr": "custom-value",
         ]
-        
+
         let options = try HoneycombOptions.Builder()
             .setAPIKey("test-key")
             .setServiceName("test-service")
@@ -855,11 +855,14 @@ final class HoneycombOptionsTests: XCTestCase {
         // Resource is always available (non-null)
         let resource = Honeycomb.resource
         let attributes = resource.attributes
-        
+
         // Test standard attributes
         XCTAssertEqual(attributes["service.name"]?.description, "test-service")
-        XCTAssertEqual(attributes["telemetry.distro.name"]?.description, "honeycomb-opentelemetry-swift")
-        
+        XCTAssertEqual(
+            attributes["telemetry.distro.name"]?.description,
+            "honeycomb-opentelemetry-swift"
+        )
+
         // Test custom attributes
         XCTAssertEqual(attributes["environment"]?.description, "test")
         XCTAssertEqual(attributes["custom.attr2"]?.description, "custom-value2")


### PR DESCRIPTION
## Which problem is this PR solving?

Adds a public `resource` property to the `Honeycomb` class that exposes the configured OpenTelemetry Resource. This matches the Android SDK functionality and provides developers with access to inspect resource attributes for debugging and validation purposes.

**Key changes:**
- Added `public static var resource: Resource` property to `Honeycomb` class
- Initializes with default OpenTelemetry Resource
- Updates to fully configured resource after `configure(options:)` is called

## How to verify that this has the expected result

1. **After configuration**: `Honeycomb.resource` returns fully configured resource with custom attributes
2. **Access attributes**: `Honeycomb.resource.attributes["service.name"]` provides service name
3. **Tests**: Run `swift test --filter testResourceExposureAfterConfiguration` to verify functionality

---

- [x] CHANGELOG is updated
- [ ] ~~README is updated with documentation~~