### PR TITLE
fix: Update to use otel-swift-core 2.1.1 and otel-swift 2.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "8bf0b58cdca5a499330b34a827aba40cb4658fbcaac94b40fa8c8dd2208dab6c",
+  "originHash" : "b65e2a5736041bad324c421d028cef43b92e3a01953132fe97fb0838e5af1dad",
   "pins" : [
-    {
-      "identity" : "datacompression",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mw99/DataCompression",
-      "state" : {
-        "revision" : "16f858982a077451ce3bdbd9144d3073ec85b6e4",
-        "version" : "3.9.0"
-      }
-    },
     {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
@@ -24,8 +15,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
       "state" : {
-        "revision" : "6cd16704ef24a8a41e301be939ab2af526963a75",
-        "version" : "2.0.2"
+        "revision" : "7a68865d9cc571cbe62c4d4902ccc0d902881eab",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "opentelemetry-swift-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core.git",
+      "state" : {
+        "revision" : "6aebc7734e154cd221ea9fb76bd4f611262be962",
+        "version" : "2.1.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
-        "version" : "2.83.0"
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b65e2a5736041bad324c421d028cef43b92e3a01953132fe97fb0838e5af1dad",
+  "originHash" : "03ae30e0f061fce8b5f061f13d1211be91d77c1321b310187e384f2605fb483f",
   "pins" : [
     {
       "identity" : "grpc-swift",

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
         .library(name: "Honeycomb", type: .static, targets: ["Honeycomb"])
     ],
     dependencies: [
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.1.1"),
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.1.0")
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", exact: "2.1.1"),
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", exact: "2.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
         .library(name: "Honeycomb", type: .static, targets: ["Honeycomb"])
     ],
     dependencies: [
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.0.2")
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", from: "2.1.1"),
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", from: "2.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -25,12 +26,12 @@ let package = Package(
             name: "Honeycomb",
             dependencies: [
                 .product(name: "BaggagePropagationProcessor", package: "opentelemetry-swift"),
-                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift"),
-                .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift"),
+                .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+                .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core"),
                 .product(name: "OpenTelemetryProtocolExporter", package: "opentelemetry-swift"),
                 .product(name: "OpenTelemetryProtocolExporterHTTP", package: "opentelemetry-swift"),
                 .product(name: "PersistenceExporter", package: "opentelemetry-swift"),
-                .product(name: "StdoutExporter", package: "opentelemetry-swift"),
+                .product(name: "StdoutExporter", package: "opentelemetry-swift-core"),
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,14 @@ let package = Package(
         .library(name: "Honeycomb", type: .static, targets: ["Honeycomb"])
     ],
     dependencies: [
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", exact: "2.1.1"),
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift.git", exact: "2.1.0")
+        .package(
+            url: "https://github.com/open-telemetry/opentelemetry-swift-core.git",
+            exact: "2.1.1"
+        ),
+        .package(
+            url: "https://github.com/open-telemetry/opentelemetry-swift.git",
+            exact: "2.1.0"
+        ),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Workspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Workspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "8bf0b58cdca5a499330b34a827aba40cb4658fbcaac94b40fa8c8dd2208dab6c",
+  "originHash" : "b65e2a5736041bad324c421d028cef43b92e3a01953132fe97fb0838e5af1dad",
   "pins" : [
-    {
-      "identity" : "datacompression",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mw99/DataCompression",
-      "state" : {
-        "revision" : "16f858982a077451ce3bdbd9144d3073ec85b6e4",
-        "version" : "3.9.0"
-      }
-    },
     {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
@@ -24,8 +15,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
       "state" : {
-        "revision" : "6cd16704ef24a8a41e301be939ab2af526963a75",
-        "version" : "2.0.2"
+        "revision" : "7a68865d9cc571cbe62c4d4902ccc0d902881eab",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "opentelemetry-swift-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core.git",
+      "state" : {
+        "revision" : "6aebc7734e154cd221ea9fb76bd4f611262be962",
+        "version" : "2.1.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
+        "version" : "1.1.2"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "d1ead62745cc3269e482f1c51f27608057174379",
-        "version" : "1.24.0"
+        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
+        "version" : "1.24.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
+        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
+        "version" : "1.36.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "7b84abbdcef69cc3be6573ac12440220789dcd69",
-        "version" : "2.27.2"
+        "revision" : "a9fa5efd86e7ce2e5c1b6de113262e58035ca251",
+        "version" : "2.27.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "e645014baea2ec1c2db564410c51a656cf47c923",
-        "version" : "1.25.1"
+        "revision" : "cd1e89816d345d2523b11c55654570acd5cd4c56",
+        "version" : "1.24.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e3f69fd321d0c9fcdc16fb576a0cdd956675face",
-        "version" : "1.31.0"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
-        "version" : "1.6.2"
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Workspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Workspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b65e2a5736041bad324c421d028cef43b92e3a01953132fe97fb0838e5af1dad",
+  "originHash" : "03ae30e0f061fce8b5f061f13d1211be91d77c1321b310187e384f2605fb483f",
   "pins" : [
     {
       "identity" : "grpc-swift",


### PR DESCRIPTION
## Short description of the changes
I was getting package resolution errors in Xcode when adding the honeycomb-opentelemetry-swift package, due to the upstream repo splitting up.
```
product ‘OpenTelemetryApi’ required by package ‘honeycomb-opentelemetry-swift’ target ‘Honeycomb’ not found in package ‘opentelemetry-swift’.
```

This PR points all the dependencies in the right places, and lets me successfully add the package in Xcode.
Apologies about the gratuitous whitespace cleanup in the README

## How to verify that this has the expected result
Verified manually by adding my fork repo as a package dependency

---

- [ ] CHANGELOG is updated
- [x] README is updated with documentation
