### PR TITLE
fix: make HoneycombNavigationPathSpanProcessor threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,19 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* fix: Make HoneycombNavigationPathSpanProcessor threadsafe.
+
 ## 2.1.2
 
-* fix: add session ID to log records
+* fix: Add session ID to log records.
 
 ## 2.1.1
 
-* fix: update to use otel-swift-core 2.1.1 and otel-swift 2.1.0
+* fix: Update to use otel-swift-core 2.1.1 and otel-swift 2.1.0.
 
 ## 2.1.0
 
-* feat: expose OpenTelemetry Resource as public property
+* feat: Expose OpenTelemetry Resource as a public property.
 
 ## 2.0.0
 
@@ -39,7 +41,7 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ### Fixes
 
-* fix: update `app.debug.buildUUID` attribute to `app.debug.build_uuid`
+* fix: Update `app.debug.buildUUID` attribute to `app.debug.build_uuid`.
 
 ## 0.0.13
 

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -20,12 +20,16 @@ func getTracer() -> Tracer {
 
 internal class HoneycombNavigationProcessor {
     static let shared = HoneycombNavigationProcessor()
-    var currentNavigationPath: [String] = []
-    var lastNavigationTime: Date? = nil
+
+    private var lock: NSLock = NSLock()
+    private var _currentNavigationPath: [String] = []
+    private var lastNavigationTime: Date? = nil
 
     private init() {
         setupAppLifecycleTracking()
     }
+    
+    public var currentNavigationPath: [String] { _currentNavigationPath }
 
     @available(tvOS 16.0, iOS 16.0, macOS 13.0, watchOS 9, *)
     func reportNavigation(prefix: String? = nil, path: NavigationPath, reason: String? = nil) {
@@ -69,9 +73,11 @@ internal class HoneycombNavigationProcessor {
         navigationEnd(reason: reason ?? "navigation")
 
         // Update current path
-        currentNavigationPath = path
-        if prefix != nil {
-            currentNavigationPath = [prefix!] + currentNavigationPath
+        lock.withLock {
+            _currentNavigationPath = path
+            if prefix != nil {
+                _currentNavigationPath = [prefix!] + _currentNavigationPath
+            }
         }
 
         navigationStart(reason: reason ?? "navigation")
@@ -98,7 +104,9 @@ internal class HoneycombNavigationProcessor {
     }
 
     func setCurrentNavigationPath(_ path: [String]) {
-        currentNavigationPath = path
+        lock.withLock {
+            _currentNavigationPath = path
+        }
     }
 
     private func setupAppLifecycleTracking() {
@@ -149,21 +157,29 @@ internal class HoneycombNavigationProcessor {
     }
 
     private func navigationEnd(reason: String) {
-        if !self.currentNavigationPath.isEmpty, let screenName = self.currentNavigationPath.last {
-            // Emit a NavigationTo span to indicate we're returning to this screen
-            let span = getTracer().spanBuilder(spanName: navigationFromSpanName).startSpan()
-            span.setAttribute(key: "screen.name", value: screenName)
-            if let lastNavTime = self.lastNavigationTime {
-                let activeTime = Date().timeIntervalSince(lastNavTime)
-                span.setAttribute(key: "screen.active.time", value: Double(activeTime))
+        var maybeScreenName: String? = nil
+        var maybeLastNavigationTime: Date? = nil
+        lock.withLock {
+            if !self._currentNavigationPath.isEmpty {
+                maybeScreenName = self._currentNavigationPath.last
             }
-            span.setAttribute(key: "navigation.trigger", value: reason)
-            span.end()
+            maybeLastNavigationTime = self.lastNavigationTime
         }
+        guard let screenName = maybeScreenName else { return }
+        
+        // Emit a NavigationTo span to indicate we're returning to this screen
+        let span = getTracer().spanBuilder(spanName: navigationFromSpanName).startSpan()
+        span.setAttribute(key: "screen.name", value: screenName)
+        if let lastNavTime = maybeLastNavigationTime {
+            let activeTime = Date().timeIntervalSince(lastNavTime)
+            span.setAttribute(key: "screen.active.time", value: Double(activeTime))
+        }
+        span.setAttribute(key: "navigation.trigger", value: reason)
+        span.end()
     }
 
     private func navigationStart(reason: String) {
-        let screenName = self.currentNavigationPath.last ?? "/"
+        let screenName = lock.withLock { self._currentNavigationPath.last ?? "/" }
 
         // Emit a NavigationTo span to indicate we're returning to this screen
         let span = getTracer().spanBuilder(spanName: navigationToSpanName).startSpan()
@@ -172,7 +188,9 @@ internal class HoneycombNavigationProcessor {
         span.end()
 
         // Update the last navigation time to now
-        self.lastNavigationTime = Date()
+        lock.withLock {
+            self.lastNavigationTime = Date()
+        }
     }
 }
 

--- a/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
+++ b/Sources/Honeycomb/HoneycombNavigationSpanInstrumentation.swift
@@ -28,7 +28,7 @@ internal class HoneycombNavigationProcessor {
     private init() {
         setupAppLifecycleTracking()
     }
-    
+
     public var currentNavigationPath: [String] { _currentNavigationPath }
 
     @available(tvOS 16.0, iOS 16.0, macOS 13.0, watchOS 9, *)
@@ -166,7 +166,7 @@ internal class HoneycombNavigationProcessor {
             maybeLastNavigationTime = self.lastNavigationTime
         }
         guard let screenName = maybeScreenName else { return }
-        
+
         // Emit a NavigationTo span to indicate we're returning to this screen
         let span = getTracer().spanBuilder(spanName: navigationFromSpanName).startSpan()
         span.setAttribute(key: "screen.name", value: screenName)


### PR DESCRIPTION
## Which problem is this PR solving?

We've had reports of crashes in the `HoneycombNavigationPathSpanProcessor`, and it looks like the handling of the current path was not threadsafe, so this PR makes it threadsafe.

## Short description of the changes

We're just guarding each access of the current path members with an `NSLock`, similar to what we did in the Session Manager.

## How to verify that this has the expected result

The smoke tests still pass.

---

- [X] CHANGELOG is updated
~- [ ] README is updated with documentation~ N/A
