### PR TITLE
feat: add missing device attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* feat: add device.manufacturer and device.model.name attributes
+
 ## 2.1.2
 
 * fix: add session ID to log records

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ All telemetry will include the following attributes
 - `telemetry.sdk.version`: Version of the OpenTelemetry Swift SDK being used.
 - [UIDevice](https://developer.apple.com/documentation/uikit/uidevice) attributes (only available on platforms where `UIKit` is available):
     - `device.id`: [UIDevice.identifierForVendor](https://developer.apple.com/documentation/uikit/uidevice/identifierforvendor)
+    - `device.manufacturer` - Hardcoded to "Apple" per [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/device/)
+    - `device.model.name` - [UIDevice.model](https://developer.apple.com/documentation/uikit/uidevice/model) per [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/device/)
     - `device.name` - [UIDevice.name](https://developer.apple.com/documentation/uikit/uidevice/name)
     - `device.systemName` - [UIDevice.systemName](https://developer.apple.com/documentation/uikit/uidevice/systemname)
     - `device.systemVersion` - [UIDevice.systemVersion](https://developer.apple.com/documentation/uikit/uidevice/systemversion)

--- a/Sources/Honeycomb/UIDeviceSpanProcessor.swift
+++ b/Sources/Honeycomb/UIDeviceSpanProcessor.swift
@@ -14,6 +14,11 @@
         ) {
             let device = UIDevice.current
 
+            // OpenTelemetry semantic conventions
+            span.setAttribute(key: "device.manufacturer", value: "Apple")
+            span.setAttribute(key: "device.model.name", value: device.model)
+
+            // Additional device attributes
             span.setAttribute(key: "device.name", value: device.name)
             span.setAttribute(key: "device.systemName", value: device.systemName)
             span.setAttribute(key: "device.systemVersion", value: device.systemVersion)

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -47,6 +47,18 @@ teardown_file() {
   assert_not_empty "$result"
 }
 
+@test "Spans have device semantic convention attributes" {
+  name="test-span"
+
+  # device.manufacturer should be hardcoded to "Apple"
+  result=$(attribute_for_span_key $SMOKE_TEST_SCOPE $name "device.manufacturer" string)
+  assert_equal "$result" '"Apple"'
+
+  # device.model.name should be present
+  result=$(attribute_for_span_key $SMOKE_TEST_SCOPE $name "device.model.name" string)
+  assert_not_empty "$result"
+}
+
 @test "SDK sends correct resource attributes" {
   result=$(resource_attributes_received | jq ".key" | sort | uniq)
   assert_equal "$result" '"app.bundle.executable"
@@ -156,7 +168,9 @@ mk_attr() {
 "device.isLowPowerModeEnabled"
 "device.isMultitaskingSupported"
 "device.localizedModel"
+"device.manufacturer"
 "device.model"
+"device.model.name"
 "device.name"
 "device.orientation"
 "device.systemName"
@@ -383,7 +397,9 @@ mk_diag_attr() {
 "device.isLowPowerModeEnabled"
 "device.isMultitaskingSupported"
 "device.localizedModel"
+"device.manufacturer"
 "device.model"
+"device.model.name"
 "device.name"
 "device.orientation"
 "device.systemName"
@@ -408,7 +424,9 @@ mk_diag_attr() {
 "device.isLowPowerModeEnabled"
 "device.isMultitaskingSupported"
 "device.localizedModel"
+"device.manufacturer"
 "device.model"
+"device.model.name"
 "device.name"
 "device.orientation"
 "device.systemName"


### PR DESCRIPTION
## Which problem is this PR solving?

Implements OpenTelemetry semantic conventions for device attributes as specified in the [OTel device registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/device/).

## Short description of the changes

- Added `device.manufacturer` attribute, hardcoded to "Apple" per OTel spec for iOS apps
- Added `device.model.name` attribute mapped from `UIDevice.model`

## How to verify that this has the expected result

1. Run the SDK on an iOS device or simulator
2. Verify that spans now include the new semantic convention attributes:
   - `device.manufacturer` = "Apple"
   - `device.model.name` = device model (e.g., "iPhone", "iPad")

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)