### PR TITLE
fix: avoid MetricKit crash by initializing CTTelephonyNetworkInfo on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* fix: Fix crash caused by initializing CTTelephonyNetworkInfo on a background thread during MetricKit diagnostics. Initialization now happens safely on the main thread.
+
 ## 2.2.0
 
 * feat: add device.manufacturer and device.model.name attributes

--- a/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
+++ b/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
@@ -19,6 +19,11 @@
             // This ensures CTTelephonyNetworkInfo is initialized during Honeycomb setup
             // (typically on main thread) rather than on background queues like MetricKit's,
             // which can cause hangs and XPC connection issues.
+            //
+            // Note: NetworkStatus holds a reference to NetworkMonitor, which actively
+            // monitors network state changes. When inject() is called, it should query
+            // the monitor for current state rather than using stale cached data.
+            // This provides both thread safety and up-to-date network information.
             networkStatus = NetworkStatus(with: monitor)
             injector = NetworkStatusInjector(netstat: networkStatus)
         }
@@ -27,7 +32,8 @@
             parentContext: SpanContext?,
             span: any ReadableSpan
         ) {
-            // Reuse the cached injector to avoid re-initializing NetworkStatus
+            // Reuse the cached NetworkStatus and injector. The NetworkMonitor reference
+            // within NetworkStatus should provide current network state on each injection.
             injector.inject(span: span)
         }
 

--- a/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
+++ b/Sources/Honeycomb/NetworkStatusSpanProcessor.swift
@@ -9,17 +9,25 @@
         public let isEndRequired = false
 
         private let networkMonitor: NetworkMonitor
+        private let networkStatus: NetworkStatus
+        private let injector: NetworkStatusInjector
 
         init(monitor: NetworkMonitor) {
             networkMonitor = monitor
+            // Initialize NetworkStatus once during processor creation to avoid
+            // CTTelephonyNetworkInfo initialization issues on background threads.
+            // This ensures CTTelephonyNetworkInfo is initialized during Honeycomb setup
+            // (typically on main thread) rather than on background queues like MetricKit's,
+            // which can cause hangs and XPC connection issues.
+            networkStatus = NetworkStatus(with: monitor)
+            injector = NetworkStatusInjector(netstat: networkStatus)
         }
 
         public func onStart(
             parentContext: SpanContext?,
             span: any ReadableSpan
         ) {
-            let status = NetworkStatus(with: networkMonitor)
-            let injector = NetworkStatusInjector(netstat: status)
+            // Reuse the cached injector to avoid re-initializing NetworkStatus
             injector.inject(span: span)
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Closes #118
Fixes a crash that occurred when CTTelephonyNetworkInfo was initialized from MetricKit’s background queue during diagnostic delivery.

## Short description of the changes

This PR moves CTTelephonyNetworkInfo initialization to the main thread to avoid unsafe synchronous XPC calls that can hang or crash when invoked from background queues like com.apple.metrickit.manager.queue.

NetworkStatusSpanProcessor now:

Sets up and keeps a single NetworkStatus instance instead of creating a new one for every span. Since NetworkStatus holds a reference to a NetworkMonitor rather than fixed values, it should still pick up the current network state when used.

This change aims to avoid the MetricKit crash while keeping network attributes accurate and up to date.

## How to verify that this has the expected result

It's an intermittent result, it will need to be validated at scale, but:

Run an app instrumented with this SDK and MetricKit enabled.

Wait for MetricKit diagnostics to trigger

Verify that spans are created successfully and no crash occurs in CTTelephonyNetworkInfo initialization.

To ensure the NetworkMonitor is updating properly after init: Confirm network-related span attributes (e.g., carrier, radio type) continue to update as expected when the device’s network changes.

---

- [ X] CHANGELOG is updated
- [ ] README is updated with documentation - not required for this fix
