### PR TITLE
feat: add option to turn off network attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Honeycomb OpenTelemetry SDK Changelog
 
 ## v.Next
 
+* feat: add `networkStatusTrackingEnabled` option to toggle collecting network status attributes 
+
 ## 2.2.0
 
 * feat: add device.manufacturer and device.model.name attributes

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Run this in your CI or as part of your build process, as relevant.
 | `uiKitInstrumentationEnabled`              | Bool     | No        | Whether to enable UIKit view instrumentation. (default: true)                                                                                              |
 | `touchInstrumentationEnabled`              | Bool     | No        | Whether to enable UIKit touch instrumentation (default: false)                                                                                             |
 | `unhandledExceptionInstrumentationEnabled` | Bool     | No        | Whether to enable unhandle exception instrumentation. (default: true)                                                                                      |
+| `networkStatusTrackingEnabled`             | Bool     | No        | Whether to include network status attributes on emitted spans. (default: true)                                                                             |
 | `offlineCachingEnabled` | Bool | No | Whether to enable offline caching for telemetry (default: false). Warning: this feature is still in alpha and may be unstable. For more details, see [Offline Caching](#offline-caching) |
 
 ## Standard Attributes

--- a/Sources/Honeycomb/Honeycomb.swift
+++ b/Sources/Honeycomb/Honeycomb.swift
@@ -152,13 +152,15 @@ public class Honeycomb {
             .add(spanProcessor: HoneycombSessionIdSpanProcessor(sessionManager: sessionManager!))
 
         #if os(iOS) && !targetEnvironment(macCatalyst)
-            do {
-                let networkMonitor = try NetworkMonitor()
-                tracerProviderBuilder =
-                    tracerProviderBuilder
-                    .add(spanProcessor: NetworkStatusSpanProcessor(monitor: networkMonitor))
-            } catch {
-                NSLog("Unable to create NetworkMonitor: \(error)")
+            if options.networkStatusTrackingEnabled {
+                do {
+                    let networkMonitor = try NetworkMonitor()
+                    tracerProviderBuilder =
+                        tracerProviderBuilder
+                        .add(spanProcessor: NetworkStatusSpanProcessor(monitor: networkMonitor))
+                } catch {
+                    NSLog("Unable to create NetworkMonitor: \(error)")
+                }
             }
         #endif
 

--- a/Sources/Honeycomb/HoneycombOptions.swift
+++ b/Sources/Honeycomb/HoneycombOptions.swift
@@ -213,6 +213,7 @@ public struct HoneycombOptions {
     let uiKitInstrumentationEnabled: Bool
     let touchInstrumentationEnabled: Bool
     let unhandledExceptionInstrumentationEnabled: Bool
+    let networkStatusTrackingEnabled: Bool
 
     let offlineCachingEnabled: Bool
     @objc(HNYOptions) open class Builder: NSObject {
@@ -260,6 +261,7 @@ public struct HoneycombOptions {
         private var uiKitInstrumentationEnabled: Bool = true
         private var touchInstrumentationEnabled: Bool = false
         private var unhandledExceptionInstrumentationEnabled: Bool = true
+        private var networkStatusTrackingEnabled: Bool = true
 
         private var offlineCachingEnabled: Bool = false
 
@@ -495,6 +497,10 @@ public struct HoneycombOptions {
             unhandledExceptionInstrumentationEnabled = enabled
             return self
         }
+        @objc public func setNetworkStatusTrackingEnabled(_ enabled: Bool) -> Builder {
+            networkStatusTrackingEnabled = enabled
+            return self
+        }
 
         @objc public func setOfflineCachingEnabled(_ enabled: Bool) -> Builder {
             offlineCachingEnabled = enabled
@@ -639,6 +645,7 @@ public struct HoneycombOptions {
                 uiKitInstrumentationEnabled: uiKitInstrumentationEnabled,
                 touchInstrumentationEnabled: touchInstrumentationEnabled,
                 unhandledExceptionInstrumentationEnabled: unhandledExceptionInstrumentationEnabled,
+                networkStatusTrackingEnabled: networkStatusTrackingEnabled,
                 offlineCachingEnabled: offlineCachingEnabled
             )
         }


### PR DESCRIPTION
## Which problem is this PR solving?
Adds a toggle to switch on/off collecting network attributes

## Short description of the changes
In case https://github.com/honeycombio/honeycomb-opentelemetry-swift/pull/119 doesn't work

## How to verify that this has the expected result
Turn it off in smoke test app, run smoke tests, observe lack of network attributes.

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
