### PR TITLE
maint: update circleci to use a current Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
           command: ./set-otel-version.sh << parameters.otel_version >>
       - run:
           name: Run iOS App
-          command: make ios-tests
+          command: SMOKE_TEST_DESTINATION="OS=18.6,name=iPhone 16" make ios-tests
       - run:
           name: Run Smoke Tests
           command: make smoke-bats

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
       - checkout
       - run: xcodebuild -version
       - run: xcodebuild -showsdks
-      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator18.6 -showdestinations
-      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator18.6 -destination 'OS=18.6,name=iPhone 16'
+      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator26.1 -showdestinations
+      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator26.1 -destination 'OS=18.6,name=iPhone 16'
 
   smoke_tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - macos/preboot-simulator:
           version: "18.6"
           platform: "iOS"
-          device: "iPhone 15"
+          device: "iPhone 16"
       - checkout
       - run: xcodebuild -version
       - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator18.6 -destination 'OS=18.6,name=iPhone 16'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ jobs:
           device: "iPhone 16"
       - checkout
       - run: xcodebuild -version
+      - run: xcodebuild -showsdks
+      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator18.6 -showdestinations
       - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator18.6 -destination 'OS=18.6,name=iPhone 16'
 
   smoke_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     macos:
       xcode: 26.1.0
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
 
     steps:
       - checkout
@@ -38,12 +38,12 @@ jobs:
 
     steps:
       - macos/preboot-simulator:
-          version: "17.5"
+          version: "18.6"
           platform: "iOS"
           device: "iPhone 15"
       - checkout
       - run: xcodebuild -version
-      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator17.5 -destination 'OS=17.5,name=iPhone 15'
+      - run: xcodebuild test -scheme HoneycombTests -sdk iphonesimulator18.6 -destination 'OS=18.6,name=iPhone 16'
 
   smoke_tests:
     parameters:
@@ -57,9 +57,9 @@ jobs:
       - attach_workspace:
           at: ./
       - macos/preboot-simulator:
-          version: "17.5"
+          version: "18.6"
           platform: "iOS"
-          device: "iPhone 15"
+          device: "iPhone 16"
       - checkout
       - bats/install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 jobs:
   lint:
     macos:
-      xcode: 16.1.0
+      xcode: 26.1.1
     resource_class: macos.m1.medium.gen1
 
     steps:
@@ -24,7 +24,7 @@ jobs:
       destination:
         type: string
     macos:
-      xcode: 15.4.0
+      xcode: 26.1.1
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -33,7 +33,7 @@ jobs:
 
   tests:
     macos:
-      xcode: 15.4.0
+      xcode: 26.1.1
     resource_class: m4pro.medium
 
     steps:
@@ -50,7 +50,7 @@ jobs:
       otel_version:
         type: string
     macos:
-      xcode: 15.4.0
+      xcode: 26.1.1
     resource_class: m4pro.medium
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 jobs:
   lint:
     macos:
-      xcode: 26.1.1
+      xcode: 26.1.0
     resource_class: macos.m1.medium.gen1
 
     steps:
@@ -24,7 +24,7 @@ jobs:
       destination:
         type: string
     macos:
-      xcode: 26.1.1
+      xcode: 26.1.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -33,7 +33,7 @@ jobs:
 
   tests:
     macos:
-      xcode: 26.1.1
+      xcode: 26.1.0
     resource_class: m4pro.medium
 
     steps:
@@ -50,7 +50,7 @@ jobs:
       otel_version:
         type: string
     macos:
-      xcode: 26.1.1
+      xcode: 26.1.0
     resource_class: m4pro.medium
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ smoke-bats: smoke-tests/collector/data.json
 	@echo ""
 	cd smoke-tests && bats ./smoke-e2e.bats --report-formatter junit --output ./
 
-smoke: smoke-docker ios-tests smoke-bats
+smoke: unsmoke clean-smoke-tests smoke-docker ios-tests smoke-bats
 
 unsmoke:
 	@echo ""

--- a/run-ios-tests.sh
+++ b/run-ios-tests.sh
@@ -3,8 +3,12 @@ set -e
 SDK=$(xcodebuild -showsdks | grep iphonesimulator | sed -e 's/^.*-sdk //')
 echo "SDK: $SDK"
 
-DESTINATION="OS=17.5,name=iPhone 15"
+if [[ "$SMOKE_TEST_DESTINATION" != "" ]]; then
+    DESTINATION="$SMOKE_TEST_DESTINATION"
+else
+    DESTINATION="OS=17.5,name=iPhone 15"
+fi
+echo "DESTINATION: $DESTINATION"
 
 xcodebuild test -scheme HoneycombTests -sdk "$SDK" -destination "$DESTINATION"
 xcodebuild test -scheme SmokeTest -sdk "$SDK" -destination "$DESTINATION"
-

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -466,9 +466,10 @@ mk_diag_attr() {
     # Apple doesn't make specific guarantees about when onAppear is called, and it seems to vary
     # based on OS version, so we need to check the attribute on a span that happens after the
     # screen is rendered.
-    result=$(attribute_for_span_key "io.honeycomb.uikit" "Touch Began" "screen.name" string \
-      | uniq \
-      | grep "View Instrumentation")
+    result=$(spans_received \
+      | jq '.scopeSpans[]?.spans[]?.attributes[]?.value.stringValue' \
+      | grep -E '^"View Instrumentation"$' \
+      | sort -u)
     assert_equal "$result" '"View Instrumentation"'
 }
 

--- a/smoke-tests/smoke-e2e.bats
+++ b/smoke-tests/smoke-e2e.bats
@@ -43,7 +43,7 @@ teardown_file() {
   assert_not_empty "$os_version"
 
   os_description="$(resource_attribute_named "os.description" string \
-    | grep -E '^"iOS Version [0-9.]+ \(Build [0-9A-F]+\)"$')"
+    | grep -E '^"iOS Version [0-9.]+ \(Build [0-9A-Z]+\)"$')"
   assert_not_empty "$os_description"
 }
 

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -86,7 +86,7 @@ resource_attributes_received() {
 }
 
 resource_attribute_named() {
-    spans_received | jq ".resource.attributes[]? | select(.key == \"$1\").value.${2}Value"
+    spans_received | jq ".resource.attributes[]? | select(.key == \"$1\").value.${2}Value" | uniq
 }
 
 # Spans for a given scope


### PR DESCRIPTION
## Which problem is this PR solving?

"Xcode Image Deprecation -  Xcode images 13.4.1, 15.1.0, 15.2.0, 15.3.0, 16.0.0, and 16.1.0 will be removed on November 7, 2025. Brownouts: Oct 22, Oct 29, Nov 5. Update your configs now to avoid job failures. [Learn more.](https://circleci.com/changelog/deprecation-of-eol-xcode-versions/)"

## Short description of the changes

* Updates the circleci config to use the latest Xcode version.
* Updates the iOS simulator and SDK versions to available versions.
* Update `"screen.name"` test that relies on `onAppear` to be more robust to Apple's changes.
* Update `"screen.path"` tests to be more robust to SwiftUI implementation details.
* Parameterize `run-ios-tests.sh` to allow passing in a `destination`.
* Update `"SDK has default resources"` test to be more resilient to different versions.
* Update `""Span Processor gets added correctly""` test to actually test something.

## How to verify that this has the expected result

The circleci tests should still pass.

---

n/a ~- [ ] CHANGELOG is updated~
n/a ~- [ ] README is updated with documentation~
