### PR TITLE
fix: guard Darwin-only otel products so Dependabot can parse Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,8 +39,6 @@ let package = Package(
                 .product(name: "PersistenceExporter", package: "opentelemetry-swift"),
                 .product(name: "Sessions", package: "opentelemetry-swift"),
                 .product(name: "StdoutExporter", package: "opentelemetry-swift-core"),
-                .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
-                .product(name: "MetricKitInstrumentation", package: "opentelemetry-swift"),
             ]
         ),
         .testTarget(
@@ -57,11 +55,18 @@ let package = Package(
 
 extension Package {
     func addPlatformSpecific() -> Self {
+        // These products are declared inside `#if canImport(Darwin)` in
+        // opentelemetry-swift, so referencing them unconditionally breaks manifest
+        // parsing on non-Darwin platforms (e.g. Dependabot's Linux updater).
         #if canImport(Darwin)
             targets[0].dependencies
                 .append(.product(name: "NetworkStatus", package: "opentelemetry-swift"))
             targets[0].dependencies
                 .append(.product(name: "ResourceExtension", package: "opentelemetry-swift"))
+            targets[0].dependencies
+                .append(.product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"))
+            targets[0].dependencies
+                .append(.product(name: "MetricKitInstrumentation", package: "opentelemetry-swift"))
         #endif
         return self
     }


### PR DESCRIPTION
## Which problem is this PR solving?

The weekly run of the `Dependabot Updates` workflow fails during manifest parsing:

```
error: 'repo': product 'URLSessionInstrumentation' required by package 'repo'
       target 'Honeycomb' not found in package 'opentelemetry-swift'.
```

`URLSessionInstrumentation` and `MetricKitInstrumentation` are declared inside `#if canImport(Darwin)` in opentelemetry-swift, so they don't exist when the manifest is evaluated off-Darwin. Dependabot's updater runs on Linux.

## Short description of the changes

Move both products into the existing `addPlatformSpecific()` Darwin block, alongside `NetworkStatus` and `ResourceExtension`, which were already handled exactly this way.

## How to verify that this has the expected result

On Apple platforms nothing changes — `swift package dump-package` yields the same 12 product dependencies for the `Honeycomb` target as before:

- [x] `swift package dump-package` — `Honeycomb` target dependencies identical pre/post
- [x] `swift build` succeeds
- [x] `make lint` clean
- [x] `Package.resolved` unchanged

After merge, force a run via Insights → Dependency graph → Dependabot → Check for updates rather than waiting for Sunday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
